### PR TITLE
avoid Memory Leak when not using cleanly

### DIFF
--- a/Source/NetOffice/COMObject.cs
+++ b/Source/NetOffice/COMObject.cs
@@ -8,6 +8,10 @@ using COMTypes = System.Runtime.InteropServices.ComTypes;
 
 namespace NetOffice
 {
+    using System.Linq;
+
+    using Weakly;
+
     /// <summary>
     /// represents a managed COM proxy 
     /// </summary>
@@ -59,7 +63,7 @@ namespace NetOffice
         /// <summary>
         ///  child instance List
         /// </summary>
-        protected internal List<COMObject> _listChildObjects = new List<COMObject>();
+        protected internal WeakCollection<COMObject> _listChildObjects = new WeakCollection<COMObject>();
 
         /// <summary>
         /// list of runtime supported entities
@@ -535,7 +539,7 @@ namespace NetOffice
         ///  child instance array
         /// </summary>
         [EditorBrowsable(EditorBrowsableState.Never), Browsable(false), Category("NetOffice")]
-        internal COMObject[] ListChildObjects
+        internal IEnumerable<COMObject> ListChildObjects
         {
             get
             {

--- a/Source/NetOffice/Core.cs
+++ b/Source/NetOffice/Core.cs
@@ -8,6 +8,10 @@ using COMTypes = System.Runtime.InteropServices.ComTypes;
 
 namespace NetOffice
 {
+    using System.Linq;
+
+    using Weakly;
+
     #region IDispatch
 
     [Guid("00020400-0000-0000-c000-000000000046"),
@@ -37,7 +41,7 @@ namespace NetOffice
 
         private bool _initalized;
         private bool _assemblyResolveEventConnected;
-        private List<COMObject> _globalObjectList = new List<COMObject>();
+        private WeakCollection<COMObject> _globalObjectList = new WeakCollection<COMObject>();
         private List<IFactoryInfo> _factoryList = new List<IFactoryInfo>();
         private Dictionary<string, Type> _proxyTypeCache = new Dictionary<string, Type>();
         private Dictionary<string, Type> _wrapperTypeCache = new Dictionary<string, Type>();
@@ -776,7 +780,7 @@ namespace NetOffice
         public void DisposeAllCOMProxies()
         {
             while (_globalObjectList.Count > 0)
-                _globalObjectList[0].Dispose();
+                _globalObjectList.First().Dispose();
         }
 
         /// <summary>

--- a/Source/NetOffice/NetOffice.csproj
+++ b/Source/NetOffice/NetOffice.csproj
@@ -68,6 +68,9 @@
     <Reference Include="System.Drawing" />
     <Reference Include="System.Windows.Forms" />
     <Reference Include="System.Xml" />
+    <Reference Include="Weakly">
+      <HintPath>..\packages\Weakly.1.4.0\lib\portable-net40+sl5+win8+wp8\Weakly.dll</HintPath>
+    </Reference>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="COMObjectExpandableObjectConverter.cs" />
@@ -150,6 +153,7 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="NetOffice_v4.0.snk" />
+    <None Include="packages.config" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
 </Project>

--- a/Source/NetOffice/packages.config
+++ b/Source/NetOffice/packages.config
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="Weakly" version="1.4.0" targetFramework="net40" />
+</packages>


### PR DESCRIPTION
- replaced List<COMObject> with WeakCollection, that way COM Proxies get garbage collected if not referenced anymore
- added Weakly nuget package (it's up to you how to cleanly integrate that into your build)