### PR TITLE
Fix bug when calling the `CorePropertySetExtensions.ExecutePropertySe…

### DIFF
--- a/Source/ADODB/DispatchInterfaces/Recordset15.cs
+++ b/Source/ADODB/DispatchInterfaces/Recordset15.cs
@@ -455,7 +455,7 @@ namespace NetOffice.ADODBApi
 		[EditorBrowsable(EditorBrowsableState.Never), Browsable(false)]
 		public void set_Collect(object index, object value)
 		{
-			Factory.ExecutePropertySet(this, "Collect", index, value);
+			Factory.ExecutePropertySet(this, "Collect", value, index);
 		}
 
 		/// <summary>

--- a/Source/ADODB/DispatchInterfaces/Recordset15_Deprecated.cs
+++ b/Source/ADODB/DispatchInterfaces/Recordset15_Deprecated.cs
@@ -455,7 +455,7 @@ namespace NetOffice.ADODBApi
 		[EditorBrowsable(EditorBrowsableState.Never), Browsable(false)]
 		public void set_Collect(object index, object value)
 		{
-			Factory.ExecutePropertySet(this, "Collect", index, value);
+			Factory.ExecutePropertySet(this, "Collect", value, index);
 		}
 
 		/// <summary>

--- a/Source/ADODB/DispatchInterfaces/Recordset21.cs
+++ b/Source/ADODB/DispatchInterfaces/Recordset21.cs
@@ -468,7 +468,7 @@ namespace NetOffice.ADODBApi
 		[EditorBrowsable(EditorBrowsableState.Never), Browsable(false)]
 		public void set_Collect(object index, object value)
 		{
-			Factory.ExecutePropertySet(this, "Collect", index, value);
+			Factory.ExecutePropertySet(this, "Collect", value, index);
 		}
 
 		/// <summary>

--- a/Source/ADODB/DispatchInterfaces/Recordset21_Deprecated.cs
+++ b/Source/ADODB/DispatchInterfaces/Recordset21_Deprecated.cs
@@ -141,7 +141,7 @@ namespace NetOffice.ADODBApi
 		[EditorBrowsable(EditorBrowsableState.Never), Browsable(false)]
 		public void set_Collect(object index, object value)
 		{
-			Factory.ExecutePropertySet(this, "Collect", index, value);
+			Factory.ExecutePropertySet(this, "Collect", value, index);
 		}
 
 		/// <summary>

--- a/Source/ADODB/DispatchInterfaces/_Recordset.cs
+++ b/Source/ADODB/DispatchInterfaces/_Recordset.cs
@@ -468,7 +468,7 @@ namespace NetOffice.ADODBApi
 		[EditorBrowsable(EditorBrowsableState.Never), Browsable(false)]
 		public void set_Collect(object index, object value)
 		{
-			Factory.ExecutePropertySet(this, "Collect", index, value);
+			Factory.ExecutePropertySet(this, "Collect", value, index);
 		}
 
 		/// <summary>

--- a/Source/Access/DispatchInterfaces/_Combobox.cs
+++ b/Source/Access/DispatchInterfaces/_Combobox.cs
@@ -2461,7 +2461,7 @@ namespace NetOffice.AccessApi
 		[EditorBrowsable(EditorBrowsableState.Never), Browsable(false)]
 		public void set_Selected(Int32 lRow, Int32 value)
 		{
-			Factory.ExecutePropertySet(this, "Selected", lRow, value);
+			Factory.ExecutePropertySet(this, "Selected", value, lRow);
 		}
 
 		/// <summary>

--- a/Source/Access/DispatchInterfaces/_Control.cs
+++ b/Source/Access/DispatchInterfaces/_Control.cs
@@ -210,7 +210,7 @@ namespace NetOffice.AccessApi
 		[EditorBrowsable(EditorBrowsableState.Never), Browsable(false)]
 		public void set_Selected(Int32 lRow, Int32 value)
 		{
-			Factory.ExecutePropertySet(this, "Selected", lRow, value);
+			Factory.ExecutePropertySet(this, "Selected", value, lRow);
 		}
 
 		/// <summary>

--- a/Source/Access/DispatchInterfaces/_ListBox.cs
+++ b/Source/Access/DispatchInterfaces/_ListBox.cs
@@ -210,7 +210,7 @@ namespace NetOffice.AccessApi
 		[EditorBrowsable(EditorBrowsableState.Never), Browsable(false)]
 		public void set_Selected(Int32 lRow, Int32 value)
 		{
-			Factory.ExecutePropertySet(this, "Selected", lRow, value);
+			Factory.ExecutePropertySet(this, "Selected", value, lRow);
 		}
 
 		/// <summary>

--- a/Source/DAO/DispatchInterfaces/Recordset.cs
+++ b/Source/DAO/DispatchInterfaces/Recordset.cs
@@ -565,7 +565,7 @@ namespace NetOffice.DAOApi
 		[EditorBrowsable(EditorBrowsableState.Never), Browsable(false)]
 		public void set_Collect(object item, object value)
 		{
-			Factory.ExecutePropertySet(this, "Collect", item, value);
+			Factory.ExecutePropertySet(this, "Collect", value, item);
 		}
 
 		/// <summary>

--- a/Source/Excel/DispatchInterfaces/AutoCorrect.cs
+++ b/Source/Excel/DispatchInterfaces/AutoCorrect.cs
@@ -100,7 +100,7 @@ namespace NetOffice.ExcelApi
 		[EditorBrowsable(EditorBrowsableState.Never), Browsable(false)]
 		public void set_ReplacementList(object index, object value)
 		{
-			Factory.ExecutePropertySet(this, "ReplacementList", index, value);
+			Factory.ExecutePropertySet(this, "ReplacementList", value, index);
 		}
 
 		/// <summary>

--- a/Source/Excel/DispatchInterfaces/DropDown.cs
+++ b/Source/Excel/DispatchInterfaces/DropDown.cs
@@ -99,7 +99,7 @@ namespace NetOffice.ExcelApi
 		[EditorBrowsable(EditorBrowsableState.Never), Browsable(false)]
 		public void set_List(object index, object value)
 		{
-			Factory.ExecutePropertySet(this, "List", index, value);
+			Factory.ExecutePropertySet(this, "List", value, index);
 		}
 
 		/// <summary>
@@ -135,7 +135,7 @@ namespace NetOffice.ExcelApi
 		[EditorBrowsable(EditorBrowsableState.Never), Browsable(false)]
 		public void set_Selected(object index, object value)
 		{
-			Factory.ExecutePropertySet(this, "Selected", index, value);
+			Factory.ExecutePropertySet(this, "Selected", value, index);
 		}
 
 		/// <summary>

--- a/Source/Excel/DispatchInterfaces/DropDowns.cs
+++ b/Source/Excel/DispatchInterfaces/DropDowns.cs
@@ -102,7 +102,7 @@ namespace NetOffice.ExcelApi
 		[EditorBrowsable(EditorBrowsableState.Never), Browsable(false)]
 		public void set_List(object index, object value)
 		{
-			Factory.ExecutePropertySet(this, "List", index, value);
+			Factory.ExecutePropertySet(this, "List", value, index);
 		}
 
 		/// <summary>
@@ -138,7 +138,7 @@ namespace NetOffice.ExcelApi
 		[EditorBrowsable(EditorBrowsableState.Never), Browsable(false)]
 		public void set_Selected(object index, object value)
 		{
-			Factory.ExecutePropertySet(this, "Selected", index, value);
+			Factory.ExecutePropertySet(this, "Selected", value, index);
 		}
 
 		/// <summary>

--- a/Source/Excel/DispatchInterfaces/ListBox.cs
+++ b/Source/Excel/DispatchInterfaces/ListBox.cs
@@ -99,7 +99,7 @@ namespace NetOffice.ExcelApi
 		[EditorBrowsable(EditorBrowsableState.Never), Browsable(false)]
 		public void set_List(object index, object value)
 		{
-			Factory.ExecutePropertySet(this, "List", index, value);
+			Factory.ExecutePropertySet(this, "List", value, index);
 		}
 
 		/// <summary>
@@ -135,7 +135,7 @@ namespace NetOffice.ExcelApi
 		[EditorBrowsable(EditorBrowsableState.Never), Browsable(false)]
 		public void set_Selected(object index, object value)
 		{
-			Factory.ExecutePropertySet(this, "Selected", index, value);
+			Factory.ExecutePropertySet(this, "Selected", value, index);
 		}
 
 		/// <summary>

--- a/Source/Excel/DispatchInterfaces/ListBoxes.cs
+++ b/Source/Excel/DispatchInterfaces/ListBoxes.cs
@@ -102,7 +102,7 @@ namespace NetOffice.ExcelApi
 		[EditorBrowsable(EditorBrowsableState.Never), Browsable(false)]
 		public void set_List(object index, object value)
 		{
-			Factory.ExecutePropertySet(this, "List", index, value);
+			Factory.ExecutePropertySet(this, "List", value, index);
 		}
 
 		/// <summary>
@@ -138,7 +138,7 @@ namespace NetOffice.ExcelApi
 		[EditorBrowsable(EditorBrowsableState.Never), Browsable(false)]
 		public void set_Selected(object index, object value)
 		{
-			Factory.ExecutePropertySet(this, "Selected", index, value);
+			Factory.ExecutePropertySet(this, "Selected", value, index);
 		}
 
 		/// <summary>

--- a/Source/Excel/DispatchInterfaces/PageSetup.cs
+++ b/Source/Excel/DispatchInterfaces/PageSetup.cs
@@ -100,7 +100,7 @@ namespace NetOffice.ExcelApi
 		[EditorBrowsable(EditorBrowsableState.Never), Browsable(false)]
 		public void set_PrintQuality(object index, object value)
 		{
-			Factory.ExecutePropertySet(this, "PrintQuality", index, value);
+			Factory.ExecutePropertySet(this, "PrintQuality", value, index);
 		}
 
 		/// <summary>

--- a/Source/Excel/DispatchInterfaces/PivotField.cs
+++ b/Source/Excel/DispatchInterfaces/PivotField.cs
@@ -175,7 +175,7 @@ namespace NetOffice.ExcelApi
 		[EditorBrowsable(EditorBrowsableState.Never), Browsable(false)]
 		public void set_Subtotals(object index, object value)
 		{
-			Factory.ExecutePropertySet(this, "Subtotals", index, value);
+			Factory.ExecutePropertySet(this, "Subtotals", value, index);
 		}
 
 		/// <summary>

--- a/Source/Excel/DispatchInterfaces/Range.cs
+++ b/Source/Excel/DispatchInterfaces/Range.cs
@@ -601,7 +601,7 @@ namespace NetOffice.ExcelApi
 		[EditorBrowsable(EditorBrowsableState.Never), Browsable(false)]
 		public void set_Value(object rangeValueDataType, object value)
 		{
-			Factory.ExecutePropertySet(this, "Value", rangeValueDataType, value);
+			Factory.ExecutePropertySet(this, "Value", value, rangeValueDataType);
 		}
 
 		/// <summary>

--- a/Source/Excel/DispatchInterfaces/RoutingSlip.cs
+++ b/Source/Excel/DispatchInterfaces/RoutingSlip.cs
@@ -100,7 +100,7 @@ namespace NetOffice.ExcelApi
 		[EditorBrowsable(EditorBrowsableState.Never), Browsable(false)]
 		public void set_Recipients(object index, object value)
 		{
-			Factory.ExecutePropertySet(this, "Recipients", index, value);
+			Factory.ExecutePropertySet(this, "Recipients", value, index);
 		}
 
 		/// <summary>

--- a/Source/Excel/DispatchInterfaces/_Chart.cs
+++ b/Source/Excel/DispatchInterfaces/_Chart.cs
@@ -141,7 +141,7 @@ namespace NetOffice.ExcelApi
 		[EditorBrowsable(EditorBrowsableState.Never), Browsable(false)]
 		public void set_HasAxis(object index1, object value)
 		{
-			Factory.ExecutePropertySet(this, "HasAxis", index1, value);
+			Factory.ExecutePropertySet(this, "HasAxis", value, index1);
 		}
 
 		/// <summary>

--- a/Source/Excel/DispatchInterfaces/_Chart.cs
+++ b/Source/Excel/DispatchInterfaces/_Chart.cs
@@ -102,7 +102,7 @@ namespace NetOffice.ExcelApi
 		[EditorBrowsable(EditorBrowsableState.Never), Browsable(false)]
 		public void set_HasAxis(object index1, object index2, object value)
 		{
-			Factory.ExecutePropertySet(this, "HasAxis", index1, index2, value);
+			Factory.ExecutePropertySet(this, "HasAxis", value, index1, index2);
 		}
 
 		/// <summary>

--- a/Source/Excel/DispatchInterfaces/_Workbook.cs
+++ b/Source/Excel/DispatchInterfaces/_Workbook.cs
@@ -101,7 +101,7 @@ namespace NetOffice.ExcelApi
 		[EditorBrowsable(EditorBrowsableState.Never), Browsable(false)]
 		public void set_Colors(object index, object value)
 		{
-			Factory.ExecutePropertySet(this, "Colors", index, value);
+			Factory.ExecutePropertySet(this, "Colors", value, index);
 		}
 
 		/// <summary>

--- a/Source/Excel/Interfaces/IAutoCorrect.cs
+++ b/Source/Excel/Interfaces/IAutoCorrect.cs
@@ -99,7 +99,7 @@ namespace NetOffice.ExcelApi
 		[EditorBrowsable(EditorBrowsableState.Never), Browsable(false)]
 		public void set_ReplacementList(object index, object value)
 		{
-			Factory.ExecutePropertySet(this, "ReplacementList", index, value);
+			Factory.ExecutePropertySet(this, "ReplacementList", value, index);
 		}
 
 		/// <summary>

--- a/Source/Excel/Interfaces/IDropDown.cs
+++ b/Source/Excel/Interfaces/IDropDown.cs
@@ -99,7 +99,7 @@ namespace NetOffice.ExcelApi
 		[EditorBrowsable(EditorBrowsableState.Never), Browsable(false)]
 		public void set_List(object index, object value)
 		{
-			Factory.ExecutePropertySet(this, "List", index, value);
+			Factory.ExecutePropertySet(this, "List", value, index);
 		}
 
 		/// <summary>
@@ -135,7 +135,7 @@ namespace NetOffice.ExcelApi
 		[EditorBrowsable(EditorBrowsableState.Never), Browsable(false)]
 		public void set_Selected(object index, object value)
 		{
-			Factory.ExecutePropertySet(this, "Selected", index, value);
+			Factory.ExecutePropertySet(this, "Selected", value, index);
 		}
 
 		/// <summary>

--- a/Source/Excel/Interfaces/IDropDowns.cs
+++ b/Source/Excel/Interfaces/IDropDowns.cs
@@ -102,7 +102,7 @@ namespace NetOffice.ExcelApi
 		[EditorBrowsable(EditorBrowsableState.Never), Browsable(false)]
 		public void set_List(object index, object value)
 		{
-			Factory.ExecutePropertySet(this, "List", index, value);
+			Factory.ExecutePropertySet(this, "List", value, index);
 		}
 
 		/// <summary>
@@ -138,7 +138,7 @@ namespace NetOffice.ExcelApi
 		[EditorBrowsable(EditorBrowsableState.Never), Browsable(false)]
 		public void set_Selected(object index, object value)
 		{
-			Factory.ExecutePropertySet(this, "Selected", index, value);
+			Factory.ExecutePropertySet(this, "Selected", value, index);
 		}
 
 		/// <summary>

--- a/Source/Excel/Interfaces/IListBox.cs
+++ b/Source/Excel/Interfaces/IListBox.cs
@@ -99,7 +99,7 @@ namespace NetOffice.ExcelApi
 		[EditorBrowsable(EditorBrowsableState.Never), Browsable(false)]
 		public void set_List(object index, object value)
 		{
-			Factory.ExecutePropertySet(this, "List", index, value);
+			Factory.ExecutePropertySet(this, "List", value, index);
 		}
 
 		/// <summary>
@@ -135,7 +135,7 @@ namespace NetOffice.ExcelApi
 		[EditorBrowsable(EditorBrowsableState.Never), Browsable(false)]
 		public void set_Selected(object index, object value)
 		{
-			Factory.ExecutePropertySet(this, "Selected", index, value);
+			Factory.ExecutePropertySet(this, "Selected", value, index);
 		}
 
 		/// <summary>

--- a/Source/Excel/Interfaces/IListBoxes.cs
+++ b/Source/Excel/Interfaces/IListBoxes.cs
@@ -102,7 +102,7 @@ namespace NetOffice.ExcelApi
 		[EditorBrowsable(EditorBrowsableState.Never), Browsable(false)]
 		public void set_List(object index, object value)
 		{
-			Factory.ExecutePropertySet(this, "List", index, value);
+			Factory.ExecutePropertySet(this, "List", value, index);
 		}
 
 		/// <summary>
@@ -138,7 +138,7 @@ namespace NetOffice.ExcelApi
 		[EditorBrowsable(EditorBrowsableState.Never), Browsable(false)]
 		public void set_Selected(object index, object value)
 		{
-			Factory.ExecutePropertySet(this, "Selected", index, value);
+			Factory.ExecutePropertySet(this, "Selected", value, index);
 		}
 
 		/// <summary>

--- a/Source/Excel/Interfaces/IPageSetup.cs
+++ b/Source/Excel/Interfaces/IPageSetup.cs
@@ -99,7 +99,7 @@ namespace NetOffice.ExcelApi
 		[EditorBrowsable(EditorBrowsableState.Never), Browsable(false)]
 		public void set_PrintQuality(object index, object value)
 		{
-			Factory.ExecutePropertySet(this, "PrintQuality", index, value);
+			Factory.ExecutePropertySet(this, "PrintQuality", value, index);
 		}
 
 		/// <summary>

--- a/Source/Excel/Interfaces/IPivotField.cs
+++ b/Source/Excel/Interfaces/IPivotField.cs
@@ -168,7 +168,7 @@ namespace NetOffice.ExcelApi
 		[EditorBrowsable(EditorBrowsableState.Never), Browsable(false)]
 		public void set_Subtotals(object index, object value)
 		{
-			Factory.ExecutePropertySet(this, "Subtotals", index, value);
+			Factory.ExecutePropertySet(this, "Subtotals", value, index);
 		}
 
 		/// <summary>

--- a/Source/Excel/Interfaces/IRange.cs
+++ b/Source/Excel/Interfaces/IRange.cs
@@ -516,7 +516,7 @@ namespace NetOffice.ExcelApi
 		[EditorBrowsable(EditorBrowsableState.Never), Browsable(false)]
 		public void set_Value(object rangeValueDataType, object value)
 		{
-			Factory.ExecutePropertySet(this, "Value", rangeValueDataType, value);
+			Factory.ExecutePropertySet(this, "Value", value, rangeValueDataType);
 		}
 
 		/// <summary>

--- a/Source/Excel/Interfaces/IRoutingSlip.cs
+++ b/Source/Excel/Interfaces/IRoutingSlip.cs
@@ -99,7 +99,7 @@ namespace NetOffice.ExcelApi
 		[EditorBrowsable(EditorBrowsableState.Never), Browsable(false)]
 		public void set_Recipients(object index, object value)
 		{
-			Factory.ExecutePropertySet(this, "Recipients", index, value);
+			Factory.ExecutePropertySet(this, "Recipients", value, index);
 		}
 
 		/// <summary>

--- a/Source/MSComctlLib/DispatchInterfaces/IButtonMenus.cs
+++ b/Source/MSComctlLib/DispatchInterfaces/IButtonMenus.cs
@@ -148,7 +148,7 @@ namespace NetOffice.MSComctlLibApi
 		[EditorBrowsable(EditorBrowsableState.Never), Browsable(false)]
 		public void set_ControlDefault(object index, NetOffice.MSComctlLibApi.IButtonMenu value)
 		{
-			Factory.ExecutePropertySet(this, "ControlDefault", index, value);
+			Factory.ExecutePropertySet(this, "ControlDefault", value, index);
 		}
 
 		/// <summary>

--- a/Source/MSComctlLib/DispatchInterfaces/IButtons.cs
+++ b/Source/MSComctlLib/DispatchInterfaces/IButtons.cs
@@ -148,7 +148,7 @@ namespace NetOffice.MSComctlLibApi
 		[EditorBrowsable(EditorBrowsableState.Never), Browsable(false)]
 		public void set_ControlDefault(object index, NetOffice.MSComctlLibApi.IButton value)
 		{
-			Factory.ExecutePropertySet(this, "ControlDefault", index, value);
+			Factory.ExecutePropertySet(this, "ControlDefault", value, index);
 		}
 
 		/// <summary>

--- a/Source/MSComctlLib/DispatchInterfaces/IComboItems.cs
+++ b/Source/MSComctlLib/DispatchInterfaces/IComboItems.cs
@@ -131,7 +131,7 @@ namespace NetOffice.MSComctlLibApi
 		[EditorBrowsable(EditorBrowsableState.Never), Browsable(false)]
 		public void set__CollectionDefault(object index, NetOffice.MSComctlLibApi.IComboItem value)
 		{
-			Factory.ExecutePropertySet(this, "_CollectionDefault", index, value);
+			Factory.ExecutePropertySet(this, "_CollectionDefault", value, index);
 		}
 
 		/// <summary>

--- a/Source/MSComctlLib/DispatchInterfaces/IImages.cs
+++ b/Source/MSComctlLib/DispatchInterfaces/IImages.cs
@@ -148,7 +148,7 @@ namespace NetOffice.MSComctlLibApi
 		[EditorBrowsable(EditorBrowsableState.Never), Browsable(false)]
 		public void set_ControlDefault(object index, NetOffice.MSComctlLibApi.IImage value)
 		{
-			Factory.ExecutePropertySet(this, "ControlDefault", index, value);
+			Factory.ExecutePropertySet(this, "ControlDefault", value, index);
 		}
 
 		/// <summary>

--- a/Source/MSComctlLib/DispatchInterfaces/IListItem.cs
+++ b/Source/MSComctlLib/DispatchInterfaces/IListItem.cs
@@ -349,7 +349,7 @@ namespace NetOffice.MSComctlLibApi
 		[EditorBrowsable(EditorBrowsableState.Never), Browsable(false)]
 		public void set_SubItems(Int16 index, string value)
 		{
-			Factory.ExecutePropertySet(this, "SubItems", index, value);
+			Factory.ExecutePropertySet(this, "SubItems", value, index);
 		}
 
 		/// <summary>

--- a/Source/MSComctlLib/DispatchInterfaces/INodes.cs
+++ b/Source/MSComctlLib/DispatchInterfaces/INodes.cs
@@ -148,7 +148,7 @@ namespace NetOffice.MSComctlLibApi
 		[EditorBrowsable(EditorBrowsableState.Never), Browsable(false)]
 		public void set_ControlDefault(object index, NetOffice.MSComctlLibApi.INode value)
 		{
-			Factory.ExecutePropertySet(this, "ControlDefault", index, value);
+			Factory.ExecutePropertySet(this, "ControlDefault", value, index);
 		}
 
 		/// <summary>

--- a/Source/MSComctlLib/DispatchInterfaces/IPanels.cs
+++ b/Source/MSComctlLib/DispatchInterfaces/IPanels.cs
@@ -148,7 +148,7 @@ namespace NetOffice.MSComctlLibApi
 		[EditorBrowsable(EditorBrowsableState.Never), Browsable(false)]
 		public void set_ControlDefault(object index, NetOffice.MSComctlLibApi.IPanel value)
 		{
-			Factory.ExecutePropertySet(this, "ControlDefault", index, value);
+			Factory.ExecutePropertySet(this, "ControlDefault", value, index);
 		}
 
 		/// <summary>

--- a/Source/MSComctlLib/DispatchInterfaces/ITabs.cs
+++ b/Source/MSComctlLib/DispatchInterfaces/ITabs.cs
@@ -148,7 +148,7 @@ namespace NetOffice.MSComctlLibApi
 		[EditorBrowsable(EditorBrowsableState.Never), Browsable(false)]
 		public void set_ControlDefault(object pvIndex, NetOffice.MSComctlLibApi.ITab value)
 		{
-			Factory.ExecutePropertySet(this, "ControlDefault", pvIndex, value);
+			Factory.ExecutePropertySet(this, "ControlDefault", value, pvIndex);
 		}
 
 		/// <summary>

--- a/Source/OWC10/DispatchInterfaces/PivotData.cs
+++ b/Source/OWC10/DispatchInterfaces/PivotData.cs
@@ -252,7 +252,7 @@ namespace NetOffice.OWC10Api
 		[EditorBrowsable(EditorBrowsableState.Never), Browsable(false)]
 		public void set_DetailLeft(NetOffice.OWC10Api.PivotColumnMember column, Int32 value)
 		{
-			Factory.ExecutePropertySet(this, "DetailLeft", column, value);
+			Factory.ExecutePropertySet(this, "DetailLeft", value, column);
 		}
 
 		/// <summary>

--- a/Source/OWC10/DispatchInterfaces/PivotField.cs
+++ b/Source/OWC10/DispatchInterfaces/PivotField.cs
@@ -222,7 +222,7 @@ namespace NetOffice.OWC10Api
 		[EditorBrowsable(EditorBrowsableState.Never), Browsable(false)]
 		public void set_Subtotals(Int32 subtotals, bool value)
 		{
-			Factory.ExecutePropertySet(this, "Subtotals", subtotals, value);
+			Factory.ExecutePropertySet(this, "Subtotals", value, subtotals);
 		}
 
 		/// <summary>

--- a/Source/OWC10/DispatchInterfaces/Workbook.cs
+++ b/Source/OWC10/DispatchInterfaces/Workbook.cs
@@ -99,7 +99,7 @@ namespace NetOffice.OWC10Api
 		[EditorBrowsable(EditorBrowsableState.Never), Browsable(false)]
 		public void set_Colors(object index, object value)
 		{
-			Factory.ExecutePropertySet(this, "Colors", index, value);
+			Factory.ExecutePropertySet(this, "Colors", value, index);
 		}
 
 		/// <summary>

--- a/Source/OWC10/DispatchInterfaces/_Range.cs
+++ b/Source/OWC10/DispatchInterfaces/_Range.cs
@@ -285,7 +285,7 @@ namespace NetOffice.OWC10Api
 		[EditorBrowsable(EditorBrowsableState.Never), Browsable(false)]
 		public void set_Value(object rangeValueDataType, object value)
 		{
-			Factory.ExecutePropertySet(this, "Value", rangeValueDataType, value);
+			Factory.ExecutePropertySet(this, "Value", value, rangeValueDataType);
 		}
 
 		/// <summary>

--- a/Source/Office/DispatchInterfaces/IAccessible.cs
+++ b/Source/Office/DispatchInterfaces/IAccessible.cs
@@ -100,7 +100,7 @@ namespace NetOffice.OfficeApi
 		[EditorBrowsable(EditorBrowsableState.Never), Browsable(false)]
 		public void set_accName(object varChild, string value)
 		{
-			Factory.ExecutePropertySet(this, "accName", varChild, value);
+			Factory.ExecutePropertySet(this, "accName", value, varChild);
 		}
 
 		/// <summary>
@@ -136,7 +136,7 @@ namespace NetOffice.OfficeApi
 		[EditorBrowsable(EditorBrowsableState.Never), Browsable(false)]
 		public void set_accValue(object varChild, string value)
 		{
-			Factory.ExecutePropertySet(this, "accValue", varChild, value);
+			Factory.ExecutePropertySet(this, "accValue", value, varChild);
 		}
 
 		/// <summary>

--- a/Source/Office/DispatchInterfaces/IMsoChart.cs
+++ b/Source/Office/DispatchInterfaces/IMsoChart.cs
@@ -154,7 +154,7 @@ namespace NetOffice.OfficeApi
 		[EditorBrowsable(EditorBrowsableState.Never), Browsable(false)]
 		public void set_HasAxis(object axisType, object axisGroup, object value)
 		{
-			Factory.ExecutePropertySet(this, "HasAxis", axisType, axisGroup, value);
+			Factory.ExecutePropertySet(this, "HasAxis", value, axisType, axisGroup);
 		}
 
 		/// <summary>

--- a/Source/Office/DispatchInterfaces/IMsoChart.cs
+++ b/Source/Office/DispatchInterfaces/IMsoChart.cs
@@ -191,7 +191,7 @@ namespace NetOffice.OfficeApi
 		[EditorBrowsable(EditorBrowsableState.Never), Browsable(false)]
 		public void set_HasAxis(object axisType, object value)
 		{
-			Factory.ExecutePropertySet(this, "HasAxis", axisType, value);
+			Factory.ExecutePropertySet(this, "HasAxis", value, axisType);
 		}
 
 		/// <summary>

--- a/Source/Office/DispatchInterfaces/_CommandBarComboBox.cs
+++ b/Source/Office/DispatchInterfaces/_CommandBarComboBox.cs
@@ -166,7 +166,7 @@ namespace NetOffice.OfficeApi
 		[EditorBrowsable(EditorBrowsableState.Never), Browsable(false)]
 		public void set_List(Int32 index, string value)
 		{
-			Factory.ExecutePropertySet(this, "List", index, value);
+			Factory.ExecutePropertySet(this, "List", value, index);
 		}
 
 		/// <summary>

--- a/Source/PowerPoint/DispatchInterfaces/Chart.cs
+++ b/Source/PowerPoint/DispatchInterfaces/Chart.cs
@@ -141,7 +141,7 @@ namespace NetOffice.PowerPointApi
 		[EditorBrowsable(EditorBrowsableState.Never), Browsable(false)]
 		public void set_HasAxis(object index1, object value)
 		{
-			Factory.ExecutePropertySet(this, "HasAxis", index1, value);
+			Factory.ExecutePropertySet(this, "HasAxis", value, index1);
 		}
 
 		/// <summary>

--- a/Source/PowerPoint/DispatchInterfaces/Chart.cs
+++ b/Source/PowerPoint/DispatchInterfaces/Chart.cs
@@ -102,7 +102,7 @@ namespace NetOffice.PowerPointApi
 		[EditorBrowsable(EditorBrowsableState.Never), Browsable(false)]
 		public void set_HasAxis(object index1, object index2, object value)
 		{
-			Factory.ExecutePropertySet(this, "HasAxis", index1, index2, value);
+			Factory.ExecutePropertySet(this, "HasAxis", value, index1, index2);
 		}
 
 		/// <summary>

--- a/Source/PowerPoint/DispatchInterfaces/PPListBox.cs
+++ b/Source/PowerPoint/DispatchInterfaces/PPListBox.cs
@@ -222,7 +222,7 @@ namespace NetOffice.PowerPointApi
 		[EditorBrowsable(EditorBrowsableState.Never), Browsable(false)]
 		public void set_IsSelected(Int32 index, NetOffice.OfficeApi.Enums.MsoTriState value)
 		{
-			Factory.ExecutePropertySet(this, "IsSelected", index, value);
+			Factory.ExecutePropertySet(this, "IsSelected", value, index);
 		}
 
 		/// <summary>

--- a/Source/VBIDE/DispatchInterfaces/Property.cs
+++ b/Source/VBIDE/DispatchInterfaces/Property.cs
@@ -266,7 +266,7 @@ namespace NetOffice.VBIDEApi
 		[EditorBrowsable(EditorBrowsableState.Never), Browsable(false)]
 		public void set_IndexedValue(object index1, object index2, object index3, object value)
 		{
-			Factory.ExecutePropertySet(this, "IndexedValue", index1, index2, index3, value);
+			Factory.ExecutePropertySet(this, "IndexedValue", value, index1, index2, index3);
 		}
 
 		/// <summary>

--- a/Source/VBIDE/DispatchInterfaces/Property.cs
+++ b/Source/VBIDE/DispatchInterfaces/Property.cs
@@ -226,7 +226,7 @@ namespace NetOffice.VBIDEApi
 		[EditorBrowsable(EditorBrowsableState.Never), Browsable(false)]
 		public void set_IndexedValue(object index1, object index2, object value)
 		{
-			Factory.ExecutePropertySet(this, "IndexedValue", index1, index2, value);
+			Factory.ExecutePropertySet(this, "IndexedValue", value, index1, index2);
 		}
 
 		/// <summary>

--- a/Source/VBIDE/DispatchInterfaces/Property.cs
+++ b/Source/VBIDE/DispatchInterfaces/Property.cs
@@ -151,7 +151,7 @@ namespace NetOffice.VBIDEApi
 		[EditorBrowsable(EditorBrowsableState.Never), Browsable(false)]
 		public void set_IndexedValue(object index1, object index2, object index3, object index4, object value)
 		{
-			Factory.ExecutePropertySet(this, "IndexedValue", new object[]{ index1, index2, index3, index4, value });
+			Factory.ExecutePropertySet(this, "IndexedValue", value, index1, index2, index3, index4);
 		}
 
 		/// <summary>

--- a/Source/VBIDE/DispatchInterfaces/Property.cs
+++ b/Source/VBIDE/DispatchInterfaces/Property.cs
@@ -189,7 +189,7 @@ namespace NetOffice.VBIDEApi
 		[EditorBrowsable(EditorBrowsableState.Never), Browsable(false)]
 		public void set_IndexedValue(object index1, object value)
 		{
-			Factory.ExecutePropertySet(this, "IndexedValue", index1, value);
+			Factory.ExecutePropertySet(this, "IndexedValue", value, index1);
 		}
 
 		/// <summary>

--- a/Source/Word/DispatchInterfaces/Chart.cs
+++ b/Source/Word/DispatchInterfaces/Chart.cs
@@ -169,7 +169,7 @@ namespace NetOffice.WordApi
 		[EditorBrowsable(EditorBrowsableState.Never), Browsable(false)]
 		public void set_HasAxis(object index1, object value)
 		{
-			Factory.ExecutePropertySet(this, "HasAxis", index1, value);
+			Factory.ExecutePropertySet(this, "HasAxis", value, index1);
 		}
 
 		/// <summary>

--- a/Source/Word/DispatchInterfaces/Chart.cs
+++ b/Source/Word/DispatchInterfaces/Chart.cs
@@ -130,7 +130,7 @@ namespace NetOffice.WordApi
 		[EditorBrowsable(EditorBrowsableState.Never), Browsable(false)]
 		public void set_HasAxis(object index1, object index2, object value)
 		{
-			Factory.ExecutePropertySet(this, "HasAxis", index1, index2, value);
+			Factory.ExecutePropertySet(this, "HasAxis", value, index1, index2);
 		}
 
 		/// <summary>

--- a/Source/Word/DispatchInterfaces/ColorFormat.cs
+++ b/Source/Word/DispatchInterfaces/ColorFormat.cs
@@ -274,7 +274,7 @@ namespace NetOffice.WordApi
 		[EditorBrowsable(EditorBrowsableState.Never), Browsable(false)]
 		public void set_Ink(Int32 index, Single value)
 		{
-			Factory.ExecutePropertySet(this, "Ink", index, value);
+			Factory.ExecutePropertySet(this, "Ink", value, index);
 		}
 
 		/// <summary>

--- a/Source/Word/DispatchInterfaces/Options.cs
+++ b/Source/Word/DispatchInterfaces/Options.cs
@@ -813,7 +813,7 @@ namespace NetOffice.WordApi
 		[EditorBrowsable(EditorBrowsableState.Never), Browsable(false)]
 		public void set_DefaultFilePath(NetOffice.WordApi.Enums.WdDefaultFilePath path, string value)
 		{
-			Factory.ExecutePropertySet(this, "DefaultFilePath", path, value);
+			Factory.ExecutePropertySet(this, "DefaultFilePath", value, path);
 		}
 
 		/// <summary>

--- a/Source/Word/DispatchInterfaces/Source.cs
+++ b/Source/Word/DispatchInterfaces/Source.cs
@@ -187,7 +187,7 @@ namespace NetOffice.WordApi
 		[EditorBrowsable(EditorBrowsableState.Never), Browsable(false)]
 		public void set_Field(string name, string value)
 		{
-			Factory.ExecutePropertySet(this, "Field", name, value);
+			Factory.ExecutePropertySet(this, "Field", value, name);
 		}
 
 		/// <summary>

--- a/Source/Word/DispatchInterfaces/System.cs
+++ b/Source/Word/DispatchInterfaces/System.cs
@@ -327,7 +327,7 @@ namespace NetOffice.WordApi
 		[EditorBrowsable(EditorBrowsableState.Never), Browsable(false)]
 		public void set_PrivateProfileString(string fileName, string section, string key, string value)
 		{
-			Factory.ExecutePropertySet(this, "PrivateProfileString", fileName, section, key, value);
+			Factory.ExecutePropertySet(this, "PrivateProfileString", value, fileName, section, key);
 		}
 
 		/// <summary>

--- a/Source/Word/DispatchInterfaces/System.cs
+++ b/Source/Word/DispatchInterfaces/System.cs
@@ -285,7 +285,7 @@ namespace NetOffice.WordApi
 		[EditorBrowsable(EditorBrowsableState.Never), Browsable(false)]
 		public void set_ProfileString(string section, string key, string value)
 		{
-			Factory.ExecutePropertySet(this, "ProfileString", section, key, value);
+			Factory.ExecutePropertySet(this, "ProfileString", value, section, key);
 		}
 
 		/// <summary>

--- a/Source/Word/DispatchInterfaces/XMLNamespace.cs
+++ b/Source/Word/DispatchInterfaces/XMLNamespace.cs
@@ -100,7 +100,7 @@ namespace NetOffice.WordApi
 		[EditorBrowsable(EditorBrowsableState.Never), Browsable(false)]
 		public void set_Location(object allUsers, string value)
 		{
-			Factory.ExecutePropertySet(this, "Location", allUsers, value);
+			Factory.ExecutePropertySet(this, "Location", value, allUsers);
 		}
 
 		/// <summary>
@@ -138,7 +138,7 @@ namespace NetOffice.WordApi
 		[EditorBrowsable(EditorBrowsableState.Never), Browsable(false)]
 		public void set_Alias(object allUsers, string value)
 		{
-			Factory.ExecutePropertySet(this, "Alias", allUsers, value);
+			Factory.ExecutePropertySet(this, "Alias", value, allUsers);
 		}
 
 		/// <summary>
@@ -176,7 +176,7 @@ namespace NetOffice.WordApi
 		[EditorBrowsable(EditorBrowsableState.Never), Browsable(false)]
 		public void set_DefaultTransform(object allUsers, NetOffice.WordApi.XSLTransform value)
 		{
-			Factory.ExecutePropertySet(this, "DefaultTransform", allUsers, value);
+			Factory.ExecutePropertySet(this, "DefaultTransform", value, allUsers);
 		}
 
 		/// <summary>

--- a/Source/Word/DispatchInterfaces/XSLTransform.cs
+++ b/Source/Word/DispatchInterfaces/XSLTransform.cs
@@ -100,7 +100,7 @@ namespace NetOffice.WordApi
 		[EditorBrowsable(EditorBrowsableState.Never), Browsable(false)]
 		public void set_Alias(object allUsers, string value)
 		{
-			Factory.ExecutePropertySet(this, "Alias", allUsers, value);
+			Factory.ExecutePropertySet(this, "Alias", value, allUsers);
 		}
 
 		/// <summary>
@@ -138,7 +138,7 @@ namespace NetOffice.WordApi
 		[EditorBrowsable(EditorBrowsableState.Never), Browsable(false)]
 		public void set_Location(object allUsers, string value)
 		{
-			Factory.ExecutePropertySet(this, "Location", allUsers, value);
+			Factory.ExecutePropertySet(this, "Location", value, allUsers);
 		}
 
 		/// <summary>

--- a/Source/Word/DispatchInterfaces/_Document.cs
+++ b/Source/Word/DispatchInterfaces/_Document.cs
@@ -923,7 +923,7 @@ namespace NetOffice.WordApi
 		[EditorBrowsable(EditorBrowsableState.Never), Browsable(false)]
 		public void set_Compatibility(NetOffice.WordApi.Enums.WdCompatibility type, bool value)
 		{
-			Factory.ExecutePropertySet(this, "Compatibility", type, value);
+			Factory.ExecutePropertySet(this, "Compatibility", value, type);
 		}
 
 		/// <summary>
@@ -1437,7 +1437,7 @@ namespace NetOffice.WordApi
 		[EditorBrowsable(EditorBrowsableState.Never), Browsable(false)]
 		public void set_ActiveWritingStyle(object languageID, string value)
 		{
-			Factory.ExecutePropertySet(this, "ActiveWritingStyle", languageID, value);
+			Factory.ExecutePropertySet(this, "ActiveWritingStyle", value, languageID);
 		}
 
 		/// <summary>


### PR DESCRIPTION
…t()` overload with one argument