### PR TITLE
Fixed build badge URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # NetOffice - Microsoft Office in .NET
 
-[![Build status](https://img.shields.io/github/workflow/status/NetOfficeFw/NetOffice/build)](https://github.com/NetOfficeFw/NetOffice/actions)
+[![Build status](https://img.shields.io/github/actions/workflow/status/NetOfficeFw/NetOffice/build.yml)](https://github.com/NetOfficeFw/NetOffice/actions)
 [![NetOfficeFw.Core](https://img.shields.io/nuget/v/netofficefw.core?label=NetOfficeFw.Core)](https://www.nuget.org/profiles/netoffice)
 [![NetOfficeFw.Outlook](https://img.shields.io/nuget/v/netofficefw.outlook?color=%230078D4&label=&logo=microsoft-outlook&style=flat-square)](https://www.nuget.org/packages/NetOfficeFw.Outlook/)
 [![NetOfficeFw.Word](https://img.shields.io/nuget/v/netofficefw.word?color=%232B579A&label=&logo=microsoft-word&style=flat-square)](https://www.nuget.org/packages/NetOfficeFw.Word/)


### PR DESCRIPTION
There was a breaking change in the shields.io build badge, I corrected the URL accordingly.