### PR TITLE
Configure `EmbedInteropTypes` value in classic nuget references

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,6 +35,11 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v3
 
+    - name: Setup dotnet
+      uses: actions/setup-dotnet@v3
+      with:
+        dotnet-version: '7.0.201'
+
     - name: Setup MSBuild
       uses: microsoft/setup-msbuild@v1.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v1.9.3
+
+### Fixed
+* Configure EmbedInteropTypes value in classic nuget references [#371](https://github.com/NetOfficeFw/NetOffice/issues/371)
+
+
 ## v1.9.2
 
 ### Fixed

--- a/Source/ADODB/Tools/install.ps1
+++ b/Source/ADODB/Tools/install.ps1
@@ -1,0 +1,7 @@
+param($installPath, $toolsPath, $package, $project)
+
+$ref = $project.Object.References.Item("ADODBApi")
+if ($ref -and $ref.EmbedInteropTypes)
+{
+    $ref.EmbedInteropTypes = $false
+}

--- a/Source/Access/Tools/install.ps1
+++ b/Source/Access/Tools/install.ps1
@@ -1,0 +1,7 @@
+param($installPath, $toolsPath, $package, $project)
+
+$ref = $project.Object.References.Item("AccessApi")
+if ($ref -and $ref.EmbedInteropTypes)
+{
+    $ref.EmbedInteropTypes = $false
+}

--- a/Source/DAO/Tools/install.ps1
+++ b/Source/DAO/Tools/install.ps1
@@ -1,0 +1,7 @@
+param($installPath, $toolsPath, $package, $project)
+
+$ref = $project.Object.References.Item("DAOApi")
+if ($ref -and $ref.EmbedInteropTypes)
+{
+    $ref.EmbedInteropTypes = $false
+}

--- a/Source/Excel/Tools/install.ps1
+++ b/Source/Excel/Tools/install.ps1
@@ -1,0 +1,7 @@
+param($installPath, $toolsPath, $package, $project)
+
+$ref = $project.Object.References.Item("ExcelApi")
+if ($ref -and $ref.EmbedInteropTypes)
+{
+    $ref.EmbedInteropTypes = $false
+}

--- a/Source/MSComctlLib/Tools/install.ps1
+++ b/Source/MSComctlLib/Tools/install.ps1
@@ -1,0 +1,7 @@
+param($installPath, $toolsPath, $package, $project)
+
+$ref = $project.Object.References.Item("MSComctlLibApi")
+if ($ref -and $ref.EmbedInteropTypes)
+{
+    $ref.EmbedInteropTypes = $false
+}

--- a/Source/MSDATASRC/Tools/install.ps1
+++ b/Source/MSDATASRC/Tools/install.ps1
@@ -1,0 +1,7 @@
+param($installPath, $toolsPath, $package, $project)
+
+$ref = $project.Object.References.Item("MSDATASRCApi")
+if ($ref -and $ref.EmbedInteropTypes)
+{
+    $ref.EmbedInteropTypes = $false
+}

--- a/Source/NetOffice.props
+++ b/Source/NetOffice.props
@@ -27,6 +27,7 @@
     <None Include="../../LICENSE.txt" Pack="true" PackagePath="/" />
     <None Include="../../icon.png" Pack="true" PackagePath="/" />
     <None Include="$(PackageReadmeFile)" Pack="true" PackagePath="/" Condition=" '$(PackageReadmeFile)' != '' " />
+    <None Include="tools/install.ps1" Pack="true" PackagePath="/tools/install.ps1" Condition=" Exists('tools/install.ps1') " />
   </ItemGroup>
 
   <PropertyGroup>

--- a/Source/NetOffice.props
+++ b/Source/NetOffice.props
@@ -1,7 +1,7 @@
 ﻿<Project>
   <!-- Common properties for NetOffice projects -->
   <PropertyGroup>
-    <NetOfficeRelease>1.9.2</NetOfficeRelease>
+    <NetOfficeRelease>1.9.3</NetOfficeRelease>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/Source/NetOffice/Tools/install.ps1
+++ b/Source/NetOffice/Tools/install.ps1
@@ -1,0 +1,7 @@
+param($installPath, $toolsPath, $package, $project)
+
+$ref = $project.Object.References.Item("NetOffice")
+if ($ref -and $ref.EmbedInteropTypes)
+{
+    $ref.EmbedInteropTypes = $false
+}

--- a/Source/OWC10/Tools/install.ps1
+++ b/Source/OWC10/Tools/install.ps1
@@ -1,0 +1,7 @@
+param($installPath, $toolsPath, $package, $project)
+
+$ref = $project.Object.References.Item("OWC10Api")
+if ($ref -and $ref.EmbedInteropTypes)
+{
+    $ref.EmbedInteropTypes = $false
+}

--- a/Source/Office/Tools/install.ps1
+++ b/Source/Office/Tools/install.ps1
@@ -1,0 +1,7 @@
+param($installPath, $toolsPath, $package, $project)
+
+$ref = $project.Object.References.Item("OfficeApi")
+if ($ref -and $ref.EmbedInteropTypes)
+{
+    $ref.EmbedInteropTypes = $false
+}

--- a/Source/Outlook/Tools/install.ps1
+++ b/Source/Outlook/Tools/install.ps1
@@ -1,0 +1,7 @@
+param($installPath, $toolsPath, $package, $project)
+
+$ref = $project.Object.References.Item("OutlookApi")
+if ($ref -and $ref.EmbedInteropTypes)
+{
+    $ref.EmbedInteropTypes = $false
+}

--- a/Source/PowerPoint/Tools/install.ps1
+++ b/Source/PowerPoint/Tools/install.ps1
@@ -1,0 +1,7 @@
+param($installPath, $toolsPath, $package, $project)
+
+$ref = $project.Object.References.Item("PowerPointApi")
+if ($ref -and $ref.EmbedInteropTypes)
+{
+    $ref.EmbedInteropTypes = $false
+}

--- a/Source/VBIDE/Tools/install.ps1
+++ b/Source/VBIDE/Tools/install.ps1
@@ -1,0 +1,7 @@
+param($installPath, $toolsPath, $package, $project)
+
+$ref = $project.Object.References.Item("VBIDEApi")
+if ($ref -and $ref.EmbedInteropTypes)
+{
+    $ref.EmbedInteropTypes = $false
+}

--- a/Source/Word/Tools/install.ps1
+++ b/Source/Word/Tools/install.ps1
@@ -1,0 +1,7 @@
+param($installPath, $toolsPath, $package, $project)
+
+$ref = $project.Object.References.Item("WordApi")
+if ($ref -and $ref.EmbedInteropTypes)
+{
+    $ref.EmbedInteropTypes = $false
+}


### PR DESCRIPTION
Include `install.ps1` script in packages to configure the `EmbedInteropTypes` value to `false` when using classic nuget references (eg. .NET Framework projects in old format).

Fixes #371 