### PR TITLE
Fix bug in `PresentationBeforeClose` code

### DIFF
--- a/Source/NetOffice.Tests/Helpers/TestableComObjectStub.cs
+++ b/Source/NetOffice.Tests/Helpers/TestableComObjectStub.cs
@@ -7,6 +7,12 @@ namespace NetOffice.Tests.Helpers
     internal class TestableComObjectStub : ICOMObject, IEventBinding
     {
         private List<ICOMObject> _children = new List<ICOMObject>();
+        private List<string> _eventRecipients = new List<string>();
+
+        public void AddEventRecipient(string eventName)
+        {
+            this._eventRecipients.Add(eventName);
+        }
 
         public bool EventBridgeInitialized => throw new NotImplementedException();
 
@@ -116,12 +122,12 @@ namespace NetOffice.Tests.Helpers
 
         public bool HasEventRecipients()
         {
-            return true;
+            return this._eventRecipients.Count > 0;
         }
 
         public bool HasEventRecipients(string eventName)
         {
-            return true;
+            return this._eventRecipients.Contains(eventName);
         }
 
         public int RaiseCustomEvent(string eventName, ref object[] paramsArray)

--- a/Source/NetOffice.Tests/PowerPointApi/Events/EApplication_SinkHelperTests.cs
+++ b/Source/NetOffice.Tests/PowerPointApi/Events/EApplication_SinkHelperTests.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright 2024 Cisco Systems, Inc.
+// Licensed under MIT-style license (see LICENSE.txt file).
+
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
@@ -21,6 +24,7 @@ namespace NetOffice.Tests.PowerPointApi.Events
         {
             // Arrange
             var eventBinder = new TestableComObjectStub();
+            eventBinder.AddEventRecipient(nameof(EApplication_SinkHelper.SlideShowBegin));
             var connectionPoint = new ConnectionPointStub();
 
             var events = new EApplication_SinkHelper(eventBinder, connectionPoint);
@@ -47,6 +51,7 @@ namespace NetOffice.Tests.PowerPointApi.Events
         {
             // Arrange
             var eventBinder = new TestableComObjectStub();
+            eventBinder.AddEventRecipient(expectedEventName);
             var connectionPoint = new ConnectionPointStub();
 
             var events = new EApplication_SinkHelper(eventBinder, connectionPoint);
@@ -61,6 +66,33 @@ namespace NetOffice.Tests.PowerPointApi.Events
             CollectionAssert.IsNotEmpty(actualParametersPassToEvent);
             var actualParameter1 = actualParametersPassToEvent[0];
             Assert.IsInstanceOf(expectedParameterType, actualParameter1, $"Event '{expectedEventName}' parameter must be of type '{expectedParameterType.Name}'");
+        }
+
+        /// <summary>
+        /// Regression test for #153 (The event PresentationBeforeClose is not triggered in PowerPoint presentations)
+        /// </summary>
+        [Test]
+        public void PresentationBeforeClose_EventRaised_CallsHandlerWithCorrectObject()
+        {
+            // Arrange
+            var eventBinder = new TestableComObjectStub();
+            eventBinder.AddEventRecipient(nameof(EApplication_SinkHelper.PresentationBeforeClose));
+            var connectionPoint = new ConnectionPointStub();
+
+            var events = new EApplication_SinkHelper(eventBinder, connectionPoint);
+            var parameter1 = new FakeComObject();
+            var boolCancel = new object();
+
+            // Act
+            events.PresentationBeforeClose(parameter1, ref boolCancel);
+            var actualParametersPassToEvent = eventBinder.LastRaisedEventParameters;
+
+            // Assert
+            Assert.AreEqual("PresentationBeforeClose", eventBinder.LastRaisedEventName);
+
+            CollectionAssert.IsNotEmpty(actualParametersPassToEvent);
+            var actualParameter1 = actualParametersPassToEvent[0];
+            Assert.IsInstanceOf<Presentation>(actualParameter1, "Event PresentationBeforeClose parameter must be of type Presentation.");
         }
 
         public static IEnumerable PowerPointSlideShowEventsTestData()

--- a/Source/PowerPoint/Events/EApplication.cs
+++ b/Source/PowerPoint/Events/EApplication.cs
@@ -575,7 +575,7 @@ namespace NetOffice.PowerPointApi.Events
 
         public void PresentationBeforeClose([In, MarshalAs(UnmanagedType.IDispatch)] object pres, [In] [Out] ref object cancel)
         {
-            if (!Validate("SlideShowOnPrevious"))
+            if (!Validate("PresentationBeforeClose"))
             {
                 Invoker.ReleaseParamsArray(pres, cancel);
                 return;


### PR DESCRIPTION
The `PresentationBeforeClose()` method will verify correct name of the registered handlers.

Updated unit tests for `EApplication_SinkHelper` by including the event recipients registration.

Fixes #153