### PR TITLE
Refactor usage of the `Assembly.CodeBase` property

### DIFF
--- a/Source/Excel/Tools/RealtimeDataServer.cs
+++ b/Source/Excel/Tools/RealtimeDataServer.cs
@@ -495,7 +495,10 @@ namespace NetOffice.ExcelApi.Tools
                     bool isSystemComponent = location.IsMachineComponentTarget(scope);
                     Assembly thisAssembly = Assembly.GetAssembly(type);
                     string assemblyVersion = thisAssembly.GetName().Version.ToString();
+#pragma warning disable SYSLIB0012 // Type or member is obsolete
+                    // although `CodeBase` is obsolete, the COM registry value requires it
                     CodebaseAttribute.CreateValue(type.GUID, isSystemComponent, assemblyVersion, thisAssembly.CodeBase);
+#pragma warning restore SYSLIB0012 // Type or member is obsolete
 
                 }
             }

--- a/Source/NetOffice.Tests/NetOffice.Tests.csproj
+++ b/Source/NetOffice.Tests/NetOffice.Tests.csproj
@@ -23,6 +23,7 @@
     <Reference Include="Microsoft.CSharp" />
   </ItemGroup>
   <ItemGroup>
+    <ProjectReference Include="..\..\Tests\NoAssemblyTitle\NoAssemblyTitle.csproj" />
     <ProjectReference Include="..\Access\AccessApi.csproj" />
     <ProjectReference Include="..\Excel\ExcelApi.csproj" />
     <ProjectReference Include="..\NetOffice\NetOffice.csproj" />

--- a/Source/NetOffice.Tests/NetOffice/Diagnostics/SelfDiagnosticsTests.cs
+++ b/Source/NetOffice.Tests/NetOffice/Diagnostics/SelfDiagnosticsTests.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using NetOffice.Diagnostics;
+using NUnit.Framework;
+
+namespace NetOffice.Tests.NetOffice
+{
+    [TestFixture]
+    public class SelfDiagnosticsTests
+    {
+        [Test]
+        public void AssemblyTitle_AssemblyWithNoAttribute_ReturnTitleBasedOnFilename()
+        {
+            // Arrange
+            var addin = new NoAssemblyTitleAddin();
+            var diag = new SelfDiagnostics(addin);
+
+            // Act
+            var title = diag.AssemblyTitle;
+
+            // Assert
+            Assert.AreEqual("NoAssemblyTitle", title);
+        }
+    }
+}

--- a/Source/NetOffice.Tests/NetOffice/Loader/PathBuilderTests.cs
+++ b/Source/NetOffice.Tests/NetOffice/Loader/PathBuilderTests.cs
@@ -10,6 +10,21 @@ namespace NetOffice.Tests.NetOffice.Loader
     public class PathBuilderTests
     {
         [Test]
+        public void BuildLocalPathFromDependentAssembly_SampleDependentAssembly_ResolvesPathToAssemblyFile()
+        {
+            // Arrange
+            var expectedAssemblyName = "NetOffice.Core.dll";
+            var assembly = new DependentAssembly(expectedAssemblyName, typeof(Core).Assembly);
+
+            // Act
+            var path = PathBuilder.BuildLocalPathFromDependentAssembly(assembly);
+
+            // Assert
+            StringAssert.EndsWith(expectedAssemblyName, path);
+            Assert.IsTrue(Path.IsPathRooted(path));
+        }
+
+        [Test]
         [TestCaseSource(nameof(NetOfficeAssemblyNameTestCase))]
         public void BuildLocalPathFromAssemblyFileName_NetOfficeAssemblyName_ResolvesPathToAssemblyFile(string assemblyName)
         {

--- a/Source/NetOffice.Tests/NetOffice/Loader/PathBuilderTests.cs
+++ b/Source/NetOffice.Tests/NetOffice/Loader/PathBuilderTests.cs
@@ -1,0 +1,35 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using NetOffice.Loader;
+using NUnit.Framework;
+
+namespace NetOffice.Tests.NetOffice.Loader
+{
+    [TestFixture]
+    public class PathBuilderTests
+    {
+        [Test]
+        [TestCaseSource(nameof(NetOfficeAssemblyNameTestCase))]
+        public void BuildLocalPathFromAssemblyFileName_NetOfficeAssemblyName_ResolvesPathToAssemblyFile(string assemblyName)
+        {
+            // Arrange
+            var factory = new Core();
+
+            // Act
+            var path = PathBuilder.BuildLocalPathFromAssemblyFileName(factory, assemblyName);
+
+            // Assert
+            StringAssert.EndsWith(assemblyName, path);
+            Assert.IsTrue(Path.IsPathRooted(path));
+        }
+
+        public static IEnumerable<string> NetOfficeAssemblyNameTestCase
+        {
+            get
+            {
+                return Core.Default.CoreDomain.AssemblyNames;
+            }
+        }
+    }
+}

--- a/Source/NetOffice.Tests/OfficeApi/Tools/AssemblyInfoTests.cs
+++ b/Source/NetOffice.Tests/OfficeApi/Tools/AssemblyInfoTests.cs
@@ -1,0 +1,26 @@
+﻿using System;
+using NetOffice.Diagnostics;
+using NetOffice.OfficeApi.Tools.Informations;
+using NUnit.Framework;
+
+namespace NetOffice.Tests.NetOffice
+{
+    [TestFixture]
+    public class AssemblyInfoTests
+    {
+        [Test]
+        public void AssemblyTitle_AssemblyWithNoAttribute_ReturnTitleBasedOnFilename()
+        {
+            // Arrange
+            var addin = new NoAssemblyTitleAddin();
+            var ownerAssembly = addin.GetType().Assembly;
+            var diag = new AssemblyInfo(ownerAssembly);
+
+            // Act
+            var title = diag.AssemblyTitle;
+
+            // Assert
+            Assert.AreEqual("NoAssemblyTitle", title);
+        }
+    }
+}

--- a/Source/NetOffice.Tests/packages.lock.json
+++ b/Source/NetOffice.Tests/packages.lock.json
@@ -56,20 +56,20 @@
       "NetOfficeFw.Access": {
         "type": "Project",
         "dependencies": {
-          "NetOfficeFw.ADODBApi": "[1.9.3, )",
-          "NetOfficeFw.Core": "[1.9.3, )",
-          "NetOfficeFw.DAOApi": "[1.9.3, )",
-          "NetOfficeFw.MSComctlLibApi": "[1.9.3, )",
-          "NetOfficeFw.MSDATASRCApi": "[1.9.3, )",
-          "NetOfficeFw.OWC10Api": "[1.9.3, )",
-          "NetOfficeFw.Office": "[1.9.3, )",
-          "NetOfficeFw.VBIDE": "[1.9.3, )"
+          "NetOfficeFw.ADODBApi": "[2.0.0, )",
+          "NetOfficeFw.Core": "[2.0.0, )",
+          "NetOfficeFw.DAOApi": "[2.0.0, )",
+          "NetOfficeFw.MSComctlLibApi": "[2.0.0, )",
+          "NetOfficeFw.MSDATASRCApi": "[2.0.0, )",
+          "NetOfficeFw.OWC10Api": "[2.0.0, )",
+          "NetOfficeFw.Office": "[2.0.0, )",
+          "NetOfficeFw.VBIDE": "[2.0.0, )"
         }
       },
       "NetOfficeFw.ADODBApi": {
         "type": "Project",
         "dependencies": {
-          "NetOfficeFw.Core": "[1.9.3, )"
+          "NetOfficeFw.Core": "[2.0.0, )"
         }
       },
       "NetOfficeFw.Core": {
@@ -78,69 +78,75 @@
       "NetOfficeFw.DAOApi": {
         "type": "Project",
         "dependencies": {
-          "NetOfficeFw.Core": "[1.9.3, )"
+          "NetOfficeFw.Core": "[2.0.0, )"
         }
       },
       "NetOfficeFw.Excel": {
         "type": "Project",
         "dependencies": {
-          "NetOfficeFw.Core": "[1.9.3, )",
-          "NetOfficeFw.Office": "[1.9.3, )",
-          "NetOfficeFw.VBIDE": "[1.9.3, )"
+          "NetOfficeFw.Core": "[2.0.0, )",
+          "NetOfficeFw.Office": "[2.0.0, )",
+          "NetOfficeFw.VBIDE": "[2.0.0, )"
         }
       },
       "NetOfficeFw.MSComctlLibApi": {
         "type": "Project",
         "dependencies": {
-          "NetOfficeFw.Core": "[1.9.3, )",
+          "NetOfficeFw.Core": "[2.0.0, )",
           "stdole": "[7.0.3300, )"
         }
       },
       "NetOfficeFw.MSDATASRCApi": {
         "type": "Project",
         "dependencies": {
-          "NetOfficeFw.Core": "[1.9.3, )"
+          "NetOfficeFw.Core": "[2.0.0, )"
         }
       },
       "NetOfficeFw.Office": {
         "type": "Project",
         "dependencies": {
-          "NetOfficeFw.Core": "[1.9.3, )",
+          "NetOfficeFw.Core": "[2.0.0, )",
           "stdole": "[7.0.3300, )"
         }
       },
       "NetOfficeFw.Outlook": {
         "type": "Project",
         "dependencies": {
-          "NetOfficeFw.Core": "[1.9.3, )",
-          "NetOfficeFw.Office": "[1.9.3, )",
+          "NetOfficeFw.Core": "[2.0.0, )",
+          "NetOfficeFw.Office": "[2.0.0, )",
           "stdole": "[7.0.3300, )"
         }
       },
       "NetOfficeFw.OWC10Api": {
         "type": "Project",
         "dependencies": {
-          "NetOfficeFw.ADODBApi": "[1.9.3, )",
-          "NetOfficeFw.Core": "[1.9.3, )",
-          "NetOfficeFw.MSComctlLibApi": "[1.9.3, )",
-          "NetOfficeFw.MSDATASRCApi": "[1.9.3, )",
+          "NetOfficeFw.ADODBApi": "[2.0.0, )",
+          "NetOfficeFw.Core": "[2.0.0, )",
+          "NetOfficeFw.MSComctlLibApi": "[2.0.0, )",
+          "NetOfficeFw.MSDATASRCApi": "[2.0.0, )",
           "stdole": "[7.0.3300, )"
         }
       },
       "NetOfficeFw.PowerPoint": {
         "type": "Project",
         "dependencies": {
-          "NetOfficeFw.Core": "[1.9.3, )",
-          "NetOfficeFw.Office": "[1.9.3, )",
-          "NetOfficeFw.VBIDE": "[1.9.3, )",
+          "NetOfficeFw.Core": "[2.0.0, )",
+          "NetOfficeFw.Office": "[2.0.0, )",
+          "NetOfficeFw.VBIDE": "[2.0.0, )",
           "stdole": "[7.0.3300, )"
         }
       },
       "NetOfficeFw.VBIDE": {
         "type": "Project",
         "dependencies": {
-          "NetOfficeFw.Core": "[1.9.3, )",
-          "NetOfficeFw.Office": "[1.9.3, )"
+          "NetOfficeFw.Core": "[2.0.0, )",
+          "NetOfficeFw.Office": "[2.0.0, )"
+        }
+      },
+      "noassemblytitle": {
+        "type": "Project",
+        "dependencies": {
+          "NetOfficeFw.Core": "[2.0.0, )"
         }
       }
     }

--- a/Source/NetOffice.sln
+++ b/Source/NetOffice.sln
@@ -47,6 +47,10 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "NetOffice.Tests", "NetOffic
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "OfficeApi.Extensions", "Office.Extensions\OfficeApi.Extensions.csproj", "{A928079E-A92E-4964-A586-EFED61ED665A}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "tests", "tests", "{F0235130-228E-419C-B21B-7F17E205C90A}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "NoAssemblyTitle", "..\Tests\NoAssemblyTitle\NoAssemblyTitle.csproj", "{5A6FBEE8-DF8A-4A52-8734-CE00289FCBB1}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -118,9 +122,16 @@ Global
 		{A928079E-A92E-4964-A586-EFED61ED665A}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{A928079E-A92E-4964-A586-EFED61ED665A}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{A928079E-A92E-4964-A586-EFED61ED665A}.Release|Any CPU.Build.0 = Release|Any CPU
+		{5A6FBEE8-DF8A-4A52-8734-CE00289FCBB1}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{5A6FBEE8-DF8A-4A52-8734-CE00289FCBB1}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{5A6FBEE8-DF8A-4A52-8734-CE00289FCBB1}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{5A6FBEE8-DF8A-4A52-8734-CE00289FCBB1}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(NestedProjects) = preSolution
+		{5A6FBEE8-DF8A-4A52-8734-CE00289FCBB1} = {F0235130-228E-419C-B21B-7F17E205C90A}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {11306061-4126-4B70-AE48-BFAA3965B8A5}

--- a/Source/NetOffice/Core.cs
+++ b/Source/NetOffice/Core.cs
@@ -483,7 +483,7 @@ namespace NetOffice
 
                     if (Settings.EnableMoreDebugOutput)
                     {
-                        string localPath = Resolver.UriResolver.ResolveLocalPath(ThisAssembly.CodeBase);
+                        string localPath = ThisAssembly.Location;
                         Console.WriteLine("Local Bind Path:{0}", localPath);
                     }
 

--- a/Source/NetOffice/Diagnostics/SelfDiagnostics.cs
+++ b/Source/NetOffice/Diagnostics/SelfDiagnostics.cs
@@ -51,7 +51,7 @@ namespace NetOffice.Diagnostics
                     if (titleAttribute.Title != String.Empty)
                         return titleAttribute.Title;
                 }
-                return System.IO.Path.GetFileNameWithoutExtension(OwnerAssembly.CodeBase);
+                return System.IO.Path.GetFileNameWithoutExtension(OwnerAssembly.Location);
             }
         }
 

--- a/Source/NetOffice/Loader/CurrentAppDomain.cs
+++ b/Source/NetOffice/Loader/CurrentAppDomain.cs
@@ -133,7 +133,7 @@ namespace NetOffice.Loader
                 versionMatch = null == localPath ? ValidateVersion(name) : ValidateVersion(localPath);
                 if (null == localPath)
                 {
-                    string thisLocalPath = Resolver.UriResolver.ResolveLocalPath(Owner.ThisAssembly.CodeBase);
+                    string thisLocalPath = Owner.ThisAssembly.Location;
                     string extension = Path.GetExtension(thisLocalPath);
                     string path = Path.GetDirectoryName(thisLocalPath);
                     localPath = Path.Combine(path, name.Name + extension);
@@ -238,7 +238,7 @@ namespace NetOffice.Loader
                 if (args.Name.ContainsIgnoreCase(".resources"))
                     return null;
 
-                string thisLocalPath = Resolver.UriResolver.ResolveLocalPath(Owner.ThisAssembly.CodeBase);
+                string thisLocalPath = Owner.ThisAssembly.Location;
                 string extension = Path.GetExtension(thisLocalPath);
                 string path = Path.GetDirectoryName(thisLocalPath);
                 string fullFileName = Path.Combine(path, args.Name + extension);

--- a/Source/NetOffice/Loader/PathBuilder.cs
+++ b/Source/NetOffice/Loader/PathBuilder.cs
@@ -14,9 +14,9 @@ namespace NetOffice.Loader
         /// <returns>resolved path</returns>
         public static string BuildLocalPathFromDependentAssembly(DependentAssembly assembly)
         {
-            string fileName = assembly.ParentAssembly.CodeBase.Substring(0, assembly.ParentAssembly.CodeBase.LastIndexOf("/")) + "/" + assembly.Name;
-            fileName = fileName.Replace("/", "\\").Substring(8);
-            return fileName;
+            string parentAssemblyDirectory = Path.GetDirectoryName(assembly.ParentAssembly.Location);
+            string localFilename = Path.Combine(parentAssemblyDirectory, assembly.Name);
+            return localFilename;
         }
 
         /// <summary>

--- a/Source/NetOffice/Loader/PathBuilder.cs
+++ b/Source/NetOffice/Loader/PathBuilder.cs
@@ -27,7 +27,7 @@ namespace NetOffice.Loader
         /// <returns>resolved path</returns>
         public static string BuildLocalPathFromAssemblyFileName(Core factory, string assemblyName)
         {
-            string localAssemblyPath = Resolver.UriResolver.ResolveLocalPath(factory.ThisAssembly.CodeBase);
+            string localAssemblyPath = Resolver.UriResolver.ResolveLocalPath(factory.ThisAssembly.Location);
             string directoryName = System.IO.Path.GetDirectoryName(localAssemblyPath);
             string fullFileName = System.IO.Path.Combine(directoryName, assemblyName);
             return fullFileName;

--- a/Source/NetOffice/Tools/COMAddinRegisterHandler.cs
+++ b/Source/NetOffice/Tools/COMAddinRegisterHandler.cs
@@ -97,7 +97,10 @@ namespace NetOffice.Tools
                     {
                         Assembly thisAssembly = Assembly.GetAssembly(type);
                         string assemblyVersion = thisAssembly.GetName().Version.ToString();
+#pragma warning disable SYSLIB0012 // Type or member is obsolete
+                        // although `CodeBase` is obsolete, the COM registry value requires it
                         CodebaseAttribute.CreateValue(type.GUID, isSystemComponent, assemblyVersion, thisAssembly.CodeBase);
+#pragma warning restore SYSLIB0012 // Type or member is obsolete
                     }
                     catch (Exception)
                     {

--- a/Source/Office/Tools/Informations/AssemblyInfo.cs
+++ b/Source/Office/Tools/Informations/AssemblyInfo.cs
@@ -60,7 +60,7 @@ namespace NetOffice.OfficeApi.Tools.Informations
                     if (titleAttribute.Title != String.Empty)
                         return titleAttribute.Title;
                 }
-                return System.IO.Path.GetFileNameWithoutExtension(OwnerAssembly.CodeBase);
+                return System.IO.Path.GetFileNameWithoutExtension(OwnerAssembly.Location);
             }
         }
 

--- a/Source/Word/Tools/DocumentInspectorBase.cs
+++ b/Source/Word/Tools/DocumentInspectorBase.cs
@@ -342,7 +342,10 @@ namespace NetOffice.WordApi.Tools
                     bool isSystemComponent = location.IsMachineComponentTarget(scope);
                     Assembly thisAssembly = Assembly.GetAssembly(type);
                     string assemblyVersion = thisAssembly.GetName().Version.ToString();
+#pragma warning disable SYSLIB0012 // Type or member is obsolete
+                    // although `CodeBase` is obsolete, the COM registry value requires it
                     CodebaseAttribute.CreateValue(type.GUID, isSystemComponent, assemblyVersion, thisAssembly.CodeBase);
+#pragma warning restore SYSLIB0012 // Type or member is obsolete
 
                 }
             }

--- a/Tests/NoAssemblyTitle/NoAssemblyTitle.csproj
+++ b/Tests/NoAssemblyTitle/NoAssemblyTitle.csproj
@@ -1,0 +1,16 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFrameworks>net462</TargetFrameworks>
+    <LangVersion>8</LangVersion>
+    <Nullable>enable</Nullable>
+    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+    <SignAssembly>True</SignAssembly>
+    <AssemblyOriginatorKeyFile>..\..\Source\NetOffice.snk</AssemblyOriginatorKeyFile>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\Source\NetOffice\NetOffice.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/Tests/NoAssemblyTitle/NoAssemblyTitleAddin.cs
+++ b/Tests/NoAssemblyTitle/NoAssemblyTitleAddin.cs
@@ -1,0 +1,117 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using NetOffice;
+using NetOffice.Availability;
+using NetOffice.Tools;
+
+/// <summary>
+/// This addin using the unit tests is in assembly
+/// without the AssemblyTitleAttribute set.
+/// </summary>
+public class NoAssemblyTitleAddin : COMAddinBase
+
+{
+    public override ICOMObject AppInstance => new NoAssemblyTitleAppInstance();
+
+    public override Core Factory => throw new NotImplementedException();
+
+    public override IEnumerable Roots { get => throw new NotImplementedException(); protected set => throw new NotImplementedException(); }
+}
+
+public class NoAssemblyTitleAppInstance : ICOMObject
+{
+    public object SyncRoot => throw new NotImplementedException();
+
+    public Core Factory => throw new NotImplementedException();
+
+    public Invoker Invoker => throw new NotImplementedException();
+
+    public Settings Settings => throw new NotImplementedException();
+
+    public DebugConsole Console => throw new NotImplementedException();
+
+    public object UnderlyingObject => throw new NotImplementedException();
+
+    public Type UnderlyingType => throw new NotImplementedException();
+
+    public string UnderlyingTypeName => throw new NotImplementedException();
+
+    public string UnderlyingFriendlyTypeName => throw new NotImplementedException();
+
+    public string UnderlyingComponentName => throw new NotImplementedException();
+
+    public string InstanceName => "NoAssemblyTitleAppInstance";
+
+    public string InstanceFriendlyName => throw new NotImplementedException();
+
+    public string InstanceComponentName => throw new NotImplementedException();
+
+    public Type InstanceType => throw new NotImplementedException();
+
+    public bool IsDisposed => throw new NotImplementedException();
+
+    public bool IsCurrentlyDisposing => throw new NotImplementedException();
+
+    public ICOMObject ParentObject => throw new NotImplementedException();
+
+    public IEnumerable<ICOMObject> ChildObjects => throw new NotImplementedException();
+
+    public bool IsEventBinding => throw new NotImplementedException();
+
+    public bool IsEventBridgeInitialized => throw new NotImplementedException();
+
+    public bool IsWithEventRecipients => throw new NotImplementedException();
+
+    public event OnDisposeEventHandler OnDispose;
+
+    public void AddChildObject(ICOMObject childObject)
+    {
+        throw new NotImplementedException();
+    }
+
+    public object Clone()
+    {
+        throw new NotImplementedException();
+    }
+
+    public void Dispose(bool disposeEventBinding)
+    {
+        throw new NotImplementedException();
+    }
+
+    public void Dispose()
+    {
+        throw new NotImplementedException();
+    }
+
+    public void DisposeChildInstances()
+    {
+        throw new NotImplementedException();
+    }
+
+    public void DisposeChildInstances(bool disposeEventBinding)
+    {
+        throw new NotImplementedException();
+    }
+
+    public bool EntityIsAvailable(string name)
+    {
+        return false;
+    }
+
+    public bool EntityIsAvailable(string name, SupportedEntityType searchType)
+    {
+        return false;
+    }
+
+    public bool RemoveChildObject(ICOMObject childObject)
+    {
+        throw new NotImplementedException();
+    }
+
+    T ICOMObject.To<T>()
+    {
+        throw new NotImplementedException();
+    }
+}


### PR DESCRIPTION
In .NET 6 the `Assembly.CodeBase` property is marked as obsolete. See #406 for more information.

Most of the code using it was refactored to use the `Location` property. The code was trying to get the equivalent of the `Location` value anyway.