### PR TITLE
Use Azure Trusted Signing service to sign release assemblies

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,15 +6,18 @@ on:
       - 'v*.*.*'
 
 permissions:
+  id-token: write
   contents: read
 
 jobs:
   release:
+    environment: production
+
     runs-on: windows-2022
 
     strategy:
       matrix:
-        configuration: [Debug, Release]
+        configuration: [Release]
 
     env:
       DOTNET_NOLOGO: 1
@@ -25,6 +28,7 @@ jobs:
       RepositoryBranch: '${{ github.ref_name }}'
       RepositoryCommit: '${{ github.sha }}'
       Configuration: '${{ matrix.configuration }}'
+      BUILD_SIGN_RELEASE: ${{ vars.BUILD_SIGN_RELEASE }}
 
     steps:
     - name: Checkout
@@ -45,14 +49,6 @@ jobs:
         path: ~/.dotnet/tools
         key: dotnettools
 
-    - name: Setup AzureSignTool
-      if: steps.cache-dotnettools.outputs.cache-hit != 'true'
-      run: dotnet tool install --verbosity minimal --global azuresigntool --version 5.0.0s
-
-    - name: Setup NuGetKeyVaultSignTool
-      if: steps.cache-dotnettools.outputs.cache-hit != 'true'
-      run: dotnet tool install --verbosity minimal --global NuGetKeyVaultSignTool --version 3.2.3
-
     - name: Cache packages
       uses: actions/cache@v4
       with:
@@ -65,32 +61,19 @@ jobs:
       id: build
       run: .\.github\Get-BuildInfo.ps1 -ref '${{ github.ref }}' -event_name '${{ github.event_name }}' -configuration '${{ matrix.configuration }}'
 
+    - name: Azure Login
+      uses: azure/login@v2
+      with:
+        client-id: ${{ secrets.TRUSTED_SIGNING_CLIENT_ID }}
+        tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+        subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+
     - name: Build NetOffice
       run: |
         dotnet build Source\NetOffice.sln
       env:
         VersionSuffix: ${{ steps.build.outputs.app_version_suffix }}
-
-    - name: Sign Files Catalog
-      run: |
-        $content = Get-Content obj/signlist.txt
-        $content = $content.Replace('${{ github.workspace }}', '..')
-        $content | Set-Content obj/signlist.txt
-
-    - name: Sign NetOffice libraries
-      if: success() && steps.build.outputs.sign_binaries == 'true'
-      uses: azure/trusted-signing-action@v0.3.19
-      with:
-          azure-tenant-id: ${{ secrets.KEYVAULT_TENANT_ID }}
-          azure-client-id: ${{ secrets.KEYVAULT_CLIENT_ID }}
-          azure-client-secret: ${{ secrets.KEYVAULT_CLIENT_SECRET }}
-          endpoint: ${{ vars.KEYVAULT_ENDPOINT }}
-          trusted-signing-account-name: ${{ vars.KEYVAULT_ACCOUNT_NAME }}
-          certificate-profile-name: ${{ secrets.KEYVAULT_CERTIFICATE_PROFILE }}
-          files-catalog: '${{ github.workspace }}/obj/signlist.txt'
-          file-digest: SHA256
-          timestamp-rfc3161: http://timestamp.acs.microsoft.com
-          timestamp-digest: SHA256
+        SignOutput: ${{ steps.build.outputs.sign_binaries }}
 
     - name: Archive NetOffice binaries
       uses: actions/upload-artifact@v4
@@ -99,6 +82,7 @@ jobs:
         path: '${{ github.workspace }}\Source\ClientApplication\bin\${{ matrix.configuration }}'
 
     - name: Pack NetOffice
+      id: packages
       if: steps.build.outputs.publish_nuget == 'true'
       run: |
         dotnet pack --no-build --no-restore Source\NetOffice.sln -c ${{ matrix.configuration }} -o dist
@@ -119,17 +103,17 @@ jobs:
     #       --azure-key-vault-client-secret "${{ secrets.KEYVAULT_CLIENT_SECRET }}" `
     #       --azure-key-vault-certificate "goITSolutions-until-2024-01"
 
+    - name: Archive NetOffice packages
+      if: steps.packages.outcome == 'success'
+      uses: actions/upload-artifact@v4
+      with:
+        name: NetOffice_packages_v${{ steps.build.outputs.app_version_full }}
+        path: '${{ github.workspace }}\dist'
+
     - name: Publish packages
-      if: success()  && steps.build.outputs.publish_nuget == 'true'
+      if: steps.packages.outcome == 'success'
       working-directory: '${{ github.workspace}}\dist'
       run: |
         dotnet nuget push *.nupkg --api-key $env:NUGET_TOKEN --source https://api.nuget.org/v3/index.json
       env:
         NUGET_TOKEN: ${{ secrets.NUGET_TOKEN }}
-
-    - name: Archive NetOffice packages
-      if: success() && steps.build.outputs.publish_nuget == 'true'
-      uses: actions/upload-artifact@v4
-      with:
-        name: NetOffice_packages_v${{ steps.build.outputs.app_version_full }}
-        path: '${{ github.workspace }}\dist'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -36,7 +36,7 @@ jobs:
     - name: Setup dotnet
       uses: actions/setup-dotnet@v4
       with:
-        dotnet-version: '7.0.201'
+        dotnet-version: 8
 
     - name: Setup MSBuild
       uses: microsoft/setup-msbuild@v2

--- a/Source/ADODB/packages.lock.json
+++ b/Source/ADODB/packages.lock.json
@@ -12,6 +12,18 @@
           "Microsoft.SourceLink.Common": "1.1.1"
         }
       },
+      "Microsoft.Trusted.Signing.Client": {
+        "type": "Direct",
+        "requested": "[1.0.60, )",
+        "resolved": "1.0.60",
+        "contentHash": "FTMmjIfofcvi3KTcyMKzAI1nIo+kvswo8HdsWWpLAomYyy85LixevLutCipU6nNv9E1iLuZWkZE6OoPhbu2QAg=="
+      },
+      "Microsoft.Windows.SDK.BuildTools": {
+        "type": "Direct",
+        "requested": "[10.0.22621.3233, )",
+        "resolved": "10.0.22621.3233",
+        "contentHash": "v67zwCb9JOpfPxdSroZukIKHruU6FUB+KwcmSPcVvUFyYtcyvcUign5y8jPQNi54CVzWvaTg646e62LbanUkxg=="
+      },
       "Microsoft.Build.Tasks.Git": {
         "type": "Transitive",
         "resolved": "1.1.1",
@@ -23,7 +35,11 @@
         "contentHash": "WMcGpWKrmJmzrNeuaEb23bEMnbtR/vLmvZtkAP5qWu7vQsY59GqfRJd65sFpBszbd2k/bQ8cs8eWawQKAabkVg=="
       },
       "NetOfficeFw.Core": {
-        "type": "Project"
+        "type": "Project",
+        "dependencies": {
+          "Microsoft.Trusted.Signing.Client": "[1.0.60, )",
+          "Microsoft.Windows.SDK.BuildTools": "[10.0.22621.3233, )"
+        }
       }
     }
   }

--- a/Source/Access/packages.lock.json
+++ b/Source/Access/packages.lock.json
@@ -12,6 +12,18 @@
           "Microsoft.SourceLink.Common": "1.1.1"
         }
       },
+      "Microsoft.Trusted.Signing.Client": {
+        "type": "Direct",
+        "requested": "[1.0.60, )",
+        "resolved": "1.0.60",
+        "contentHash": "FTMmjIfofcvi3KTcyMKzAI1nIo+kvswo8HdsWWpLAomYyy85LixevLutCipU6nNv9E1iLuZWkZE6OoPhbu2QAg=="
+      },
+      "Microsoft.Windows.SDK.BuildTools": {
+        "type": "Direct",
+        "requested": "[10.0.22621.3233, )",
+        "resolved": "10.0.22621.3233",
+        "contentHash": "v67zwCb9JOpfPxdSroZukIKHruU6FUB+KwcmSPcVvUFyYtcyvcUign5y8jPQNi54CVzWvaTg646e62LbanUkxg=="
+      },
       "Microsoft.Build.Tasks.Git": {
         "type": "Transitive",
         "resolved": "1.1.1",
@@ -30,53 +42,71 @@
       "NetOfficeFw.ADODBApi": {
         "type": "Project",
         "dependencies": {
-          "NetOfficeFw.Core": "[1.9.3, )"
+          "Microsoft.Trusted.Signing.Client": "[1.0.60, )",
+          "Microsoft.Windows.SDK.BuildTools": "[10.0.22621.3233, )",
+          "NetOfficeFw.Core": "[2.0.0, )"
         }
       },
       "NetOfficeFw.Core": {
-        "type": "Project"
+        "type": "Project",
+        "dependencies": {
+          "Microsoft.Trusted.Signing.Client": "[1.0.60, )",
+          "Microsoft.Windows.SDK.BuildTools": "[10.0.22621.3233, )"
+        }
       },
       "NetOfficeFw.DAOApi": {
         "type": "Project",
         "dependencies": {
-          "NetOfficeFw.Core": "[1.9.3, )"
+          "Microsoft.Trusted.Signing.Client": "[1.0.60, )",
+          "Microsoft.Windows.SDK.BuildTools": "[10.0.22621.3233, )",
+          "NetOfficeFw.Core": "[2.0.0, )"
         }
       },
       "NetOfficeFw.MSComctlLibApi": {
         "type": "Project",
         "dependencies": {
-          "NetOfficeFw.Core": "[1.9.3, )",
+          "Microsoft.Trusted.Signing.Client": "[1.0.60, )",
+          "Microsoft.Windows.SDK.BuildTools": "[10.0.22621.3233, )",
+          "NetOfficeFw.Core": "[2.0.0, )",
           "stdole": "[7.0.3300, )"
         }
       },
       "NetOfficeFw.MSDATASRCApi": {
         "type": "Project",
         "dependencies": {
-          "NetOfficeFw.Core": "[1.9.3, )"
+          "Microsoft.Trusted.Signing.Client": "[1.0.60, )",
+          "Microsoft.Windows.SDK.BuildTools": "[10.0.22621.3233, )",
+          "NetOfficeFw.Core": "[2.0.0, )"
         }
       },
       "NetOfficeFw.Office": {
         "type": "Project",
         "dependencies": {
-          "NetOfficeFw.Core": "[1.9.3, )",
+          "Microsoft.Trusted.Signing.Client": "[1.0.60, )",
+          "Microsoft.Windows.SDK.BuildTools": "[10.0.22621.3233, )",
+          "NetOfficeFw.Core": "[2.0.0, )",
           "stdole": "[7.0.3300, )"
         }
       },
       "NetOfficeFw.OWC10Api": {
         "type": "Project",
         "dependencies": {
-          "NetOfficeFw.ADODBApi": "[1.9.3, )",
-          "NetOfficeFw.Core": "[1.9.3, )",
-          "NetOfficeFw.MSComctlLibApi": "[1.9.3, )",
-          "NetOfficeFw.MSDATASRCApi": "[1.9.3, )",
+          "Microsoft.Trusted.Signing.Client": "[1.0.60, )",
+          "Microsoft.Windows.SDK.BuildTools": "[10.0.22621.3233, )",
+          "NetOfficeFw.ADODBApi": "[2.0.0, )",
+          "NetOfficeFw.Core": "[2.0.0, )",
+          "NetOfficeFw.MSComctlLibApi": "[2.0.0, )",
+          "NetOfficeFw.MSDATASRCApi": "[2.0.0, )",
           "stdole": "[7.0.3300, )"
         }
       },
       "NetOfficeFw.VBIDE": {
         "type": "Project",
         "dependencies": {
-          "NetOfficeFw.Core": "[1.9.3, )",
-          "NetOfficeFw.Office": "[1.9.3, )"
+          "Microsoft.Trusted.Signing.Client": "[1.0.60, )",
+          "Microsoft.Windows.SDK.BuildTools": "[10.0.22621.3233, )",
+          "NetOfficeFw.Core": "[2.0.0, )",
+          "NetOfficeFw.Office": "[2.0.0, )"
         }
       }
     }

--- a/Source/ClientApplication/packages.lock.json
+++ b/Source/ClientApplication/packages.lock.json
@@ -12,6 +12,18 @@
           "Microsoft.SourceLink.Common": "1.1.1"
         }
       },
+      "Microsoft.Trusted.Signing.Client": {
+        "type": "Direct",
+        "requested": "[1.0.60, )",
+        "resolved": "1.0.60",
+        "contentHash": "FTMmjIfofcvi3KTcyMKzAI1nIo+kvswo8HdsWWpLAomYyy85LixevLutCipU6nNv9E1iLuZWkZE6OoPhbu2QAg=="
+      },
+      "Microsoft.Windows.SDK.BuildTools": {
+        "type": "Direct",
+        "requested": "[10.0.22621.3233, )",
+        "resolved": "10.0.22621.3233",
+        "contentHash": "v67zwCb9JOpfPxdSroZukIKHruU6FUB+KwcmSPcVvUFyYtcyvcUign5y8jPQNi54CVzWvaTg646e62LbanUkxg=="
+      },
       "Microsoft.Build.Tasks.Git": {
         "type": "Transitive",
         "resolved": "1.1.1",
@@ -63,106 +75,136 @@
       "NetOfficeFw.Access": {
         "type": "Project",
         "dependencies": {
-          "NetOfficeFw.ADODBApi": "[1.9.3, )",
-          "NetOfficeFw.Core": "[1.9.3, )",
-          "NetOfficeFw.DAOApi": "[1.9.3, )",
-          "NetOfficeFw.MSComctlLibApi": "[1.9.3, )",
-          "NetOfficeFw.MSDATASRCApi": "[1.9.3, )",
-          "NetOfficeFw.OWC10Api": "[1.9.3, )",
-          "NetOfficeFw.Office": "[1.9.3, )",
-          "NetOfficeFw.VBIDE": "[1.9.3, )"
+          "Microsoft.Trusted.Signing.Client": "[1.0.60, )",
+          "Microsoft.Windows.SDK.BuildTools": "[10.0.22621.3233, )",
+          "NetOfficeFw.ADODBApi": "[2.0.0, )",
+          "NetOfficeFw.Core": "[2.0.0, )",
+          "NetOfficeFw.DAOApi": "[2.0.0, )",
+          "NetOfficeFw.MSComctlLibApi": "[2.0.0, )",
+          "NetOfficeFw.MSDATASRCApi": "[2.0.0, )",
+          "NetOfficeFw.OWC10Api": "[2.0.0, )",
+          "NetOfficeFw.Office": "[2.0.0, )",
+          "NetOfficeFw.VBIDE": "[2.0.0, )"
         }
       },
       "NetOfficeFw.ADODBApi": {
         "type": "Project",
         "dependencies": {
-          "NetOfficeFw.Core": "[1.9.3, )"
+          "Microsoft.Trusted.Signing.Client": "[1.0.60, )",
+          "Microsoft.Windows.SDK.BuildTools": "[10.0.22621.3233, )",
+          "NetOfficeFw.Core": "[2.0.0, )"
         }
       },
       "NetOfficeFw.Core": {
-        "type": "Project"
+        "type": "Project",
+        "dependencies": {
+          "Microsoft.Trusted.Signing.Client": "[1.0.60, )",
+          "Microsoft.Windows.SDK.BuildTools": "[10.0.22621.3233, )"
+        }
       },
       "NetOfficeFw.DAOApi": {
         "type": "Project",
         "dependencies": {
-          "NetOfficeFw.Core": "[1.9.3, )"
+          "Microsoft.Trusted.Signing.Client": "[1.0.60, )",
+          "Microsoft.Windows.SDK.BuildTools": "[10.0.22621.3233, )",
+          "NetOfficeFw.Core": "[2.0.0, )"
         }
       },
       "NetOfficeFw.Excel": {
         "type": "Project",
         "dependencies": {
-          "NetOfficeFw.Core": "[1.9.3, )",
-          "NetOfficeFw.Office": "[1.9.3, )",
-          "NetOfficeFw.VBIDE": "[1.9.3, )"
+          "Microsoft.Trusted.Signing.Client": "[1.0.60, )",
+          "Microsoft.Windows.SDK.BuildTools": "[10.0.22621.3233, )",
+          "NetOfficeFw.Core": "[2.0.0, )",
+          "NetOfficeFw.Office": "[2.0.0, )",
+          "NetOfficeFw.VBIDE": "[2.0.0, )"
         }
       },
       "NetOfficeFw.MSComctlLibApi": {
         "type": "Project",
         "dependencies": {
-          "NetOfficeFw.Core": "[1.9.3, )",
+          "Microsoft.Trusted.Signing.Client": "[1.0.60, )",
+          "Microsoft.Windows.SDK.BuildTools": "[10.0.22621.3233, )",
+          "NetOfficeFw.Core": "[2.0.0, )",
           "stdole": "[7.0.3300, )"
         }
       },
       "NetOfficeFw.MSDATASRCApi": {
         "type": "Project",
         "dependencies": {
-          "NetOfficeFw.Core": "[1.9.3, )"
+          "Microsoft.Trusted.Signing.Client": "[1.0.60, )",
+          "Microsoft.Windows.SDK.BuildTools": "[10.0.22621.3233, )",
+          "NetOfficeFw.Core": "[2.0.0, )"
         }
       },
       "NetOfficeFw.Office": {
         "type": "Project",
         "dependencies": {
-          "NetOfficeFw.Core": "[1.9.3, )",
+          "Microsoft.Trusted.Signing.Client": "[1.0.60, )",
+          "Microsoft.Windows.SDK.BuildTools": "[10.0.22621.3233, )",
+          "NetOfficeFw.Core": "[2.0.0, )",
           "stdole": "[7.0.3300, )"
         }
       },
       "NetOfficeFw.Office.Extensions": {
         "type": "Project",
         "dependencies": {
-          "NetOfficeFw.Office": "[1.9.3, )",
+          "Microsoft.Trusted.Signing.Client": "[1.0.60, )",
+          "Microsoft.Windows.SDK.BuildTools": "[10.0.22621.3233, )",
+          "NetOfficeFw.Office": "[2.0.0, )",
           "System.Resources.Extensions": "[6.0.0, )"
         }
       },
       "NetOfficeFw.Outlook": {
         "type": "Project",
         "dependencies": {
-          "NetOfficeFw.Core": "[1.9.3, )",
-          "NetOfficeFw.Office": "[1.9.3, )",
+          "Microsoft.Trusted.Signing.Client": "[1.0.60, )",
+          "Microsoft.Windows.SDK.BuildTools": "[10.0.22621.3233, )",
+          "NetOfficeFw.Core": "[2.0.0, )",
+          "NetOfficeFw.Office": "[2.0.0, )",
           "stdole": "[7.0.3300, )"
         }
       },
       "NetOfficeFw.OWC10Api": {
         "type": "Project",
         "dependencies": {
-          "NetOfficeFw.ADODBApi": "[1.9.3, )",
-          "NetOfficeFw.Core": "[1.9.3, )",
-          "NetOfficeFw.MSComctlLibApi": "[1.9.3, )",
-          "NetOfficeFw.MSDATASRCApi": "[1.9.3, )",
+          "Microsoft.Trusted.Signing.Client": "[1.0.60, )",
+          "Microsoft.Windows.SDK.BuildTools": "[10.0.22621.3233, )",
+          "NetOfficeFw.ADODBApi": "[2.0.0, )",
+          "NetOfficeFw.Core": "[2.0.0, )",
+          "NetOfficeFw.MSComctlLibApi": "[2.0.0, )",
+          "NetOfficeFw.MSDATASRCApi": "[2.0.0, )",
           "stdole": "[7.0.3300, )"
         }
       },
       "NetOfficeFw.PowerPoint": {
         "type": "Project",
         "dependencies": {
-          "NetOfficeFw.Core": "[1.9.3, )",
-          "NetOfficeFw.Office": "[1.9.3, )",
-          "NetOfficeFw.VBIDE": "[1.9.3, )",
+          "Microsoft.Trusted.Signing.Client": "[1.0.60, )",
+          "Microsoft.Windows.SDK.BuildTools": "[10.0.22621.3233, )",
+          "NetOfficeFw.Core": "[2.0.0, )",
+          "NetOfficeFw.Office": "[2.0.0, )",
+          "NetOfficeFw.VBIDE": "[2.0.0, )",
           "stdole": "[7.0.3300, )"
         }
       },
       "NetOfficeFw.VBIDE": {
         "type": "Project",
         "dependencies": {
-          "NetOfficeFw.Core": "[1.9.3, )",
-          "NetOfficeFw.Office": "[1.9.3, )"
+          "Microsoft.Trusted.Signing.Client": "[1.0.60, )",
+          "Microsoft.Windows.SDK.BuildTools": "[10.0.22621.3233, )",
+          "NetOfficeFw.Core": "[2.0.0, )",
+          "NetOfficeFw.Office": "[2.0.0, )"
         }
       },
       "NetOfficeFw.Word": {
         "type": "Project",
         "dependencies": {
-          "NetOfficeFw.Core": "[1.9.3, )",
-          "NetOfficeFw.Office": "[1.9.3, )",
-          "NetOfficeFw.VBIDE": "[1.9.3, )",
+          "Microsoft.Trusted.Signing.Client": "[1.0.60, )",
+          "Microsoft.Windows.SDK.BuildTools": "[10.0.22621.3233, )",
+          "NetOfficeFw.Core": "[2.0.0, )",
+          "NetOfficeFw.Office": "[2.0.0, )",
+          "NetOfficeFw.VBIDE": "[2.0.0, )",
           "stdole": "[7.0.3300, )"
         }
       }

--- a/Source/DAO/packages.lock.json
+++ b/Source/DAO/packages.lock.json
@@ -12,6 +12,18 @@
           "Microsoft.SourceLink.Common": "1.1.1"
         }
       },
+      "Microsoft.Trusted.Signing.Client": {
+        "type": "Direct",
+        "requested": "[1.0.60, )",
+        "resolved": "1.0.60",
+        "contentHash": "FTMmjIfofcvi3KTcyMKzAI1nIo+kvswo8HdsWWpLAomYyy85LixevLutCipU6nNv9E1iLuZWkZE6OoPhbu2QAg=="
+      },
+      "Microsoft.Windows.SDK.BuildTools": {
+        "type": "Direct",
+        "requested": "[10.0.22621.3233, )",
+        "resolved": "10.0.22621.3233",
+        "contentHash": "v67zwCb9JOpfPxdSroZukIKHruU6FUB+KwcmSPcVvUFyYtcyvcUign5y8jPQNi54CVzWvaTg646e62LbanUkxg=="
+      },
       "Microsoft.Build.Tasks.Git": {
         "type": "Transitive",
         "resolved": "1.1.1",
@@ -23,7 +35,11 @@
         "contentHash": "WMcGpWKrmJmzrNeuaEb23bEMnbtR/vLmvZtkAP5qWu7vQsY59GqfRJd65sFpBszbd2k/bQ8cs8eWawQKAabkVg=="
       },
       "NetOfficeFw.Core": {
-        "type": "Project"
+        "type": "Project",
+        "dependencies": {
+          "Microsoft.Trusted.Signing.Client": "[1.0.60, )",
+          "Microsoft.Windows.SDK.BuildTools": "[10.0.22621.3233, )"
+        }
       }
     }
   }

--- a/Source/Directory.Build.targets
+++ b/Source/Directory.Build.targets
@@ -1,5 +1,36 @@
 <Project>
+
+  <PropertyGroup>
+    <AfterBuildDependsOn>
+      $(AfterBuildDependsOn);
+      SignOutputTarget;
+    </AfterBuildDependsOn>
+  </PropertyGroup>
+
   <Target Name="AfterBuild" DependsOnTargets="$(AfterBuildDependsOn)">
-    <WriteLinesToFile File="$(SignListPath)" Lines="$(TargetPath)" />
+  </Target>
+
+  <ItemGroup>
+    <TargetToSign Include="$(TargetPath)" Condition=" '$(ConfigurationType)' == 'DynamicLibrary' Or '$(ConfigurationType)' == 'Application' Or '$(OutputType)' == 'Library' Or '$(OutputType)' == 'Exe' ">
+      <SignToolLogFile>$(IntermediateOutputPath)$(ProjectName)_signtool.log</SignToolLogFile>
+    </TargetToSign>
+  </ItemGroup>
+
+  <!--
+    Signs output file $(TargetPath) using authenticode certificate.
+    We use the Azure Trusted Signing service to sign files.
+    Configuration is set in the `trustedsigning.json` file.
+  -->
+  <Target Name="SignOutputTarget"
+          Outputs="@(TargetToSign)"
+          Condition=" '$(SignOutput)' == 'true' And '@(TargetToSign)' != '' ">
+    <Message Text="Signing file %(TargetToSign.FullPath)" Importance="High" />
+
+    <PropertyGroup>
+      <TrustedSigningDlibArg>/dlib "$(TrustedSigningDlibFilePath)"</TrustedSigningDlibArg>
+      <TrustedSigningDlibConfigArg>/dmdf "$(TrustedSigningConfigPath)"</TrustedSigningDlibConfigArg>
+    </PropertyGroup>
+
+    <Exec Command="&quot;$(SignAppxPackageExeFullPath)&quot; sign /v /debug /fd sha256 /td sha256 /tr $(SignTimestampServer) $(TrustedSigningDlibArg) $(TrustedSigningDlibConfigArg) &quot;%(TargetToSign.FullPath)&quot; &gt; &quot;%(TargetToSign.SignToolLogFile)&quot;" />
   </Target>
 </Project>

--- a/Source/Excel/packages.lock.json
+++ b/Source/Excel/packages.lock.json
@@ -12,6 +12,18 @@
           "Microsoft.SourceLink.Common": "1.1.1"
         }
       },
+      "Microsoft.Trusted.Signing.Client": {
+        "type": "Direct",
+        "requested": "[1.0.60, )",
+        "resolved": "1.0.60",
+        "contentHash": "FTMmjIfofcvi3KTcyMKzAI1nIo+kvswo8HdsWWpLAomYyy85LixevLutCipU6nNv9E1iLuZWkZE6OoPhbu2QAg=="
+      },
+      "Microsoft.Windows.SDK.BuildTools": {
+        "type": "Direct",
+        "requested": "[10.0.22621.3233, )",
+        "resolved": "10.0.22621.3233",
+        "contentHash": "v67zwCb9JOpfPxdSroZukIKHruU6FUB+KwcmSPcVvUFyYtcyvcUign5y8jPQNi54CVzWvaTg646e62LbanUkxg=="
+      },
       "Microsoft.Build.Tasks.Git": {
         "type": "Transitive",
         "resolved": "1.1.1",
@@ -28,20 +40,28 @@
         "contentHash": "p9WhjNp/gM2z80u+xNA1XXFek57iybUUJaDnQooKfdct3vGIpmDzLdL7Rq4ZmFzZc3LN3SFs5bRIE7j/+gLn5Q=="
       },
       "NetOfficeFw.Core": {
-        "type": "Project"
+        "type": "Project",
+        "dependencies": {
+          "Microsoft.Trusted.Signing.Client": "[1.0.60, )",
+          "Microsoft.Windows.SDK.BuildTools": "[10.0.22621.3233, )"
+        }
       },
       "NetOfficeFw.Office": {
         "type": "Project",
         "dependencies": {
-          "NetOfficeFw.Core": "[1.9.3, )",
+          "Microsoft.Trusted.Signing.Client": "[1.0.60, )",
+          "Microsoft.Windows.SDK.BuildTools": "[10.0.22621.3233, )",
+          "NetOfficeFw.Core": "[2.0.0, )",
           "stdole": "[7.0.3300, )"
         }
       },
       "NetOfficeFw.VBIDE": {
         "type": "Project",
         "dependencies": {
-          "NetOfficeFw.Core": "[1.9.3, )",
-          "NetOfficeFw.Office": "[1.9.3, )"
+          "Microsoft.Trusted.Signing.Client": "[1.0.60, )",
+          "Microsoft.Windows.SDK.BuildTools": "[10.0.22621.3233, )",
+          "NetOfficeFw.Core": "[2.0.0, )",
+          "NetOfficeFw.Office": "[2.0.0, )"
         }
       }
     }

--- a/Source/MSComctlLib/packages.lock.json
+++ b/Source/MSComctlLib/packages.lock.json
@@ -12,6 +12,18 @@
           "Microsoft.SourceLink.Common": "1.1.1"
         }
       },
+      "Microsoft.Trusted.Signing.Client": {
+        "type": "Direct",
+        "requested": "[1.0.60, )",
+        "resolved": "1.0.60",
+        "contentHash": "FTMmjIfofcvi3KTcyMKzAI1nIo+kvswo8HdsWWpLAomYyy85LixevLutCipU6nNv9E1iLuZWkZE6OoPhbu2QAg=="
+      },
+      "Microsoft.Windows.SDK.BuildTools": {
+        "type": "Direct",
+        "requested": "[10.0.22621.3233, )",
+        "resolved": "10.0.22621.3233",
+        "contentHash": "v67zwCb9JOpfPxdSroZukIKHruU6FUB+KwcmSPcVvUFyYtcyvcUign5y8jPQNi54CVzWvaTg646e62LbanUkxg=="
+      },
       "stdole": {
         "type": "Direct",
         "requested": "[7.0.3300, )",
@@ -29,7 +41,11 @@
         "contentHash": "WMcGpWKrmJmzrNeuaEb23bEMnbtR/vLmvZtkAP5qWu7vQsY59GqfRJd65sFpBszbd2k/bQ8cs8eWawQKAabkVg=="
       },
       "NetOfficeFw.Core": {
-        "type": "Project"
+        "type": "Project",
+        "dependencies": {
+          "Microsoft.Trusted.Signing.Client": "[1.0.60, )",
+          "Microsoft.Windows.SDK.BuildTools": "[10.0.22621.3233, )"
+        }
       }
     }
   }

--- a/Source/MSDATASRC/packages.lock.json
+++ b/Source/MSDATASRC/packages.lock.json
@@ -12,6 +12,18 @@
           "Microsoft.SourceLink.Common": "1.1.1"
         }
       },
+      "Microsoft.Trusted.Signing.Client": {
+        "type": "Direct",
+        "requested": "[1.0.60, )",
+        "resolved": "1.0.60",
+        "contentHash": "FTMmjIfofcvi3KTcyMKzAI1nIo+kvswo8HdsWWpLAomYyy85LixevLutCipU6nNv9E1iLuZWkZE6OoPhbu2QAg=="
+      },
+      "Microsoft.Windows.SDK.BuildTools": {
+        "type": "Direct",
+        "requested": "[10.0.22621.3233, )",
+        "resolved": "10.0.22621.3233",
+        "contentHash": "v67zwCb9JOpfPxdSroZukIKHruU6FUB+KwcmSPcVvUFyYtcyvcUign5y8jPQNi54CVzWvaTg646e62LbanUkxg=="
+      },
       "Microsoft.Build.Tasks.Git": {
         "type": "Transitive",
         "resolved": "1.1.1",
@@ -23,7 +35,11 @@
         "contentHash": "WMcGpWKrmJmzrNeuaEb23bEMnbtR/vLmvZtkAP5qWu7vQsY59GqfRJd65sFpBszbd2k/bQ8cs8eWawQKAabkVg=="
       },
       "NetOfficeFw.Core": {
-        "type": "Project"
+        "type": "Project",
+        "dependencies": {
+          "Microsoft.Trusted.Signing.Client": "[1.0.60, )",
+          "Microsoft.Windows.SDK.BuildTools": "[10.0.22621.3233, )"
+        }
       }
     }
   }

--- a/Source/NetOffice.Tests/packages.lock.json
+++ b/Source/NetOffice.Tests/packages.lock.json
@@ -21,6 +21,18 @@
           "Microsoft.SourceLink.Common": "1.1.1"
         }
       },
+      "Microsoft.Trusted.Signing.Client": {
+        "type": "Direct",
+        "requested": "[1.0.60, )",
+        "resolved": "1.0.60",
+        "contentHash": "FTMmjIfofcvi3KTcyMKzAI1nIo+kvswo8HdsWWpLAomYyy85LixevLutCipU6nNv9E1iLuZWkZE6OoPhbu2QAg=="
+      },
+      "Microsoft.Windows.SDK.BuildTools": {
+        "type": "Direct",
+        "requested": "[10.0.22621.3233, )",
+        "resolved": "10.0.22621.3233",
+        "contentHash": "v67zwCb9JOpfPxdSroZukIKHruU6FUB+KwcmSPcVvUFyYtcyvcUign5y8jPQNi54CVzWvaTg646e62LbanUkxg=="
+      },
       "NUnit": {
         "type": "Direct",
         "requested": "[3.13.3, )",
@@ -56,6 +68,8 @@
       "NetOfficeFw.Access": {
         "type": "Project",
         "dependencies": {
+          "Microsoft.Trusted.Signing.Client": "[1.0.60, )",
+          "Microsoft.Windows.SDK.BuildTools": "[10.0.22621.3233, )",
           "NetOfficeFw.ADODBApi": "[2.0.0, )",
           "NetOfficeFw.Core": "[2.0.0, )",
           "NetOfficeFw.DAOApi": "[2.0.0, )",
@@ -69,21 +83,31 @@
       "NetOfficeFw.ADODBApi": {
         "type": "Project",
         "dependencies": {
+          "Microsoft.Trusted.Signing.Client": "[1.0.60, )",
+          "Microsoft.Windows.SDK.BuildTools": "[10.0.22621.3233, )",
           "NetOfficeFw.Core": "[2.0.0, )"
         }
       },
       "NetOfficeFw.Core": {
-        "type": "Project"
+        "type": "Project",
+        "dependencies": {
+          "Microsoft.Trusted.Signing.Client": "[1.0.60, )",
+          "Microsoft.Windows.SDK.BuildTools": "[10.0.22621.3233, )"
+        }
       },
       "NetOfficeFw.DAOApi": {
         "type": "Project",
         "dependencies": {
+          "Microsoft.Trusted.Signing.Client": "[1.0.60, )",
+          "Microsoft.Windows.SDK.BuildTools": "[10.0.22621.3233, )",
           "NetOfficeFw.Core": "[2.0.0, )"
         }
       },
       "NetOfficeFw.Excel": {
         "type": "Project",
         "dependencies": {
+          "Microsoft.Trusted.Signing.Client": "[1.0.60, )",
+          "Microsoft.Windows.SDK.BuildTools": "[10.0.22621.3233, )",
           "NetOfficeFw.Core": "[2.0.0, )",
           "NetOfficeFw.Office": "[2.0.0, )",
           "NetOfficeFw.VBIDE": "[2.0.0, )"
@@ -92,6 +116,8 @@
       "NetOfficeFw.MSComctlLibApi": {
         "type": "Project",
         "dependencies": {
+          "Microsoft.Trusted.Signing.Client": "[1.0.60, )",
+          "Microsoft.Windows.SDK.BuildTools": "[10.0.22621.3233, )",
           "NetOfficeFw.Core": "[2.0.0, )",
           "stdole": "[7.0.3300, )"
         }
@@ -99,12 +125,16 @@
       "NetOfficeFw.MSDATASRCApi": {
         "type": "Project",
         "dependencies": {
+          "Microsoft.Trusted.Signing.Client": "[1.0.60, )",
+          "Microsoft.Windows.SDK.BuildTools": "[10.0.22621.3233, )",
           "NetOfficeFw.Core": "[2.0.0, )"
         }
       },
       "NetOfficeFw.Office": {
         "type": "Project",
         "dependencies": {
+          "Microsoft.Trusted.Signing.Client": "[1.0.60, )",
+          "Microsoft.Windows.SDK.BuildTools": "[10.0.22621.3233, )",
           "NetOfficeFw.Core": "[2.0.0, )",
           "stdole": "[7.0.3300, )"
         }
@@ -112,6 +142,8 @@
       "NetOfficeFw.Outlook": {
         "type": "Project",
         "dependencies": {
+          "Microsoft.Trusted.Signing.Client": "[1.0.60, )",
+          "Microsoft.Windows.SDK.BuildTools": "[10.0.22621.3233, )",
           "NetOfficeFw.Core": "[2.0.0, )",
           "NetOfficeFw.Office": "[2.0.0, )",
           "stdole": "[7.0.3300, )"
@@ -120,6 +152,8 @@
       "NetOfficeFw.OWC10Api": {
         "type": "Project",
         "dependencies": {
+          "Microsoft.Trusted.Signing.Client": "[1.0.60, )",
+          "Microsoft.Windows.SDK.BuildTools": "[10.0.22621.3233, )",
           "NetOfficeFw.ADODBApi": "[2.0.0, )",
           "NetOfficeFw.Core": "[2.0.0, )",
           "NetOfficeFw.MSComctlLibApi": "[2.0.0, )",
@@ -130,6 +164,8 @@
       "NetOfficeFw.PowerPoint": {
         "type": "Project",
         "dependencies": {
+          "Microsoft.Trusted.Signing.Client": "[1.0.60, )",
+          "Microsoft.Windows.SDK.BuildTools": "[10.0.22621.3233, )",
           "NetOfficeFw.Core": "[2.0.0, )",
           "NetOfficeFw.Office": "[2.0.0, )",
           "NetOfficeFw.VBIDE": "[2.0.0, )",
@@ -139,6 +175,8 @@
       "NetOfficeFw.VBIDE": {
         "type": "Project",
         "dependencies": {
+          "Microsoft.Trusted.Signing.Client": "[1.0.60, )",
+          "Microsoft.Windows.SDK.BuildTools": "[10.0.22621.3233, )",
           "NetOfficeFw.Core": "[2.0.0, )",
           "NetOfficeFw.Office": "[2.0.0, )"
         }

--- a/Source/NetOffice.props
+++ b/Source/NetOffice.props
@@ -59,7 +59,8 @@
 
   <!-- Authenticode signing -->
   <PropertyGroup>
-    <SignListPath Condition=" '$(SignListPath)' == '' ">$(MSBuildThisFileDirectory)..\obj\signlist.txt</SignListPath>
+    <SignTimestampServer>http://timestamp.acs.microsoft.com/</SignTimestampServer>
+    <TrustedSigningConfigPath>$(MSBuildThisFileDirectory)trustedsigning.json</TrustedSigningConfigPath>
   </PropertyGroup>
 
   <ItemGroup>
@@ -70,5 +71,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.22621.3233" />
+    <PackageReference Include="Microsoft.Trusted.Signing.Client" Version="1.0.60" />
   </ItemGroup>
 </Project>

--- a/Source/NetOffice.props
+++ b/Source/NetOffice.props
@@ -59,6 +59,7 @@
 
   <!-- Authenticode signing -->
   <PropertyGroup>
+    <SignOutput Condition=" '$(SignOutput)' == '' ">false</SignOutput>
     <SignTimestampServer>http://timestamp.acs.microsoft.com/</SignTimestampServer>
     <TrustedSigningConfigPath>$(MSBuildThisFileDirectory)trustedsigning.json</TrustedSigningConfigPath>
   </PropertyGroup>

--- a/Source/NetOffice/packages.lock.json
+++ b/Source/NetOffice/packages.lock.json
@@ -12,6 +12,18 @@
           "Microsoft.SourceLink.Common": "1.1.1"
         }
       },
+      "Microsoft.Trusted.Signing.Client": {
+        "type": "Direct",
+        "requested": "[1.0.60, )",
+        "resolved": "1.0.60",
+        "contentHash": "FTMmjIfofcvi3KTcyMKzAI1nIo+kvswo8HdsWWpLAomYyy85LixevLutCipU6nNv9E1iLuZWkZE6OoPhbu2QAg=="
+      },
+      "Microsoft.Windows.SDK.BuildTools": {
+        "type": "Direct",
+        "requested": "[10.0.22621.3233, )",
+        "resolved": "10.0.22621.3233",
+        "contentHash": "v67zwCb9JOpfPxdSroZukIKHruU6FUB+KwcmSPcVvUFyYtcyvcUign5y8jPQNi54CVzWvaTg646e62LbanUkxg=="
+      },
       "Microsoft.Build.Tasks.Git": {
         "type": "Transitive",
         "resolved": "1.1.1",

--- a/Source/OWC10/packages.lock.json
+++ b/Source/OWC10/packages.lock.json
@@ -12,6 +12,18 @@
           "Microsoft.SourceLink.Common": "1.1.1"
         }
       },
+      "Microsoft.Trusted.Signing.Client": {
+        "type": "Direct",
+        "requested": "[1.0.60, )",
+        "resolved": "1.0.60",
+        "contentHash": "FTMmjIfofcvi3KTcyMKzAI1nIo+kvswo8HdsWWpLAomYyy85LixevLutCipU6nNv9E1iLuZWkZE6OoPhbu2QAg=="
+      },
+      "Microsoft.Windows.SDK.BuildTools": {
+        "type": "Direct",
+        "requested": "[10.0.22621.3233, )",
+        "resolved": "10.0.22621.3233",
+        "contentHash": "v67zwCb9JOpfPxdSroZukIKHruU6FUB+KwcmSPcVvUFyYtcyvcUign5y8jPQNi54CVzWvaTg646e62LbanUkxg=="
+      },
       "stdole": {
         "type": "Direct",
         "requested": "[7.0.3300, )",
@@ -31,23 +43,33 @@
       "NetOfficeFw.ADODBApi": {
         "type": "Project",
         "dependencies": {
-          "NetOfficeFw.Core": "[1.9.3, )"
+          "Microsoft.Trusted.Signing.Client": "[1.0.60, )",
+          "Microsoft.Windows.SDK.BuildTools": "[10.0.22621.3233, )",
+          "NetOfficeFw.Core": "[2.0.0, )"
         }
       },
       "NetOfficeFw.Core": {
-        "type": "Project"
+        "type": "Project",
+        "dependencies": {
+          "Microsoft.Trusted.Signing.Client": "[1.0.60, )",
+          "Microsoft.Windows.SDK.BuildTools": "[10.0.22621.3233, )"
+        }
       },
       "NetOfficeFw.MSComctlLibApi": {
         "type": "Project",
         "dependencies": {
-          "NetOfficeFw.Core": "[1.9.3, )",
+          "Microsoft.Trusted.Signing.Client": "[1.0.60, )",
+          "Microsoft.Windows.SDK.BuildTools": "[10.0.22621.3233, )",
+          "NetOfficeFw.Core": "[2.0.0, )",
           "stdole": "[7.0.3300, )"
         }
       },
       "NetOfficeFw.MSDATASRCApi": {
         "type": "Project",
         "dependencies": {
-          "NetOfficeFw.Core": "[1.9.3, )"
+          "Microsoft.Trusted.Signing.Client": "[1.0.60, )",
+          "Microsoft.Windows.SDK.BuildTools": "[10.0.22621.3233, )",
+          "NetOfficeFw.Core": "[2.0.0, )"
         }
       }
     }

--- a/Source/Office.Extensions/packages.lock.json
+++ b/Source/Office.Extensions/packages.lock.json
@@ -12,6 +12,18 @@
           "Microsoft.SourceLink.Common": "1.1.1"
         }
       },
+      "Microsoft.Trusted.Signing.Client": {
+        "type": "Direct",
+        "requested": "[1.0.60, )",
+        "resolved": "1.0.60",
+        "contentHash": "FTMmjIfofcvi3KTcyMKzAI1nIo+kvswo8HdsWWpLAomYyy85LixevLutCipU6nNv9E1iLuZWkZE6OoPhbu2QAg=="
+      },
+      "Microsoft.Windows.SDK.BuildTools": {
+        "type": "Direct",
+        "requested": "[10.0.22621.3233, )",
+        "resolved": "10.0.22621.3233",
+        "contentHash": "v67zwCb9JOpfPxdSroZukIKHruU6FUB+KwcmSPcVvUFyYtcyvcUign5y8jPQNi54CVzWvaTg646e62LbanUkxg=="
+      },
       "System.Resources.Extensions": {
         "type": "Direct",
         "requested": "[6.0.0, )",
@@ -62,12 +74,18 @@
         "contentHash": "3TIsJhD1EiiT0w2CcDMN/iSSwnNnsrnbzeVHSKkaEgV85txMprmuO+Yq2AdSbeVGcg28pdNDTPK87tJhX7VFHw=="
       },
       "NetOfficeFw.Core": {
-        "type": "Project"
+        "type": "Project",
+        "dependencies": {
+          "Microsoft.Trusted.Signing.Client": "[1.0.60, )",
+          "Microsoft.Windows.SDK.BuildTools": "[10.0.22621.3233, )"
+        }
       },
       "NetOfficeFw.Office": {
         "type": "Project",
         "dependencies": {
-          "NetOfficeFw.Core": "[1.9.3, )",
+          "Microsoft.Trusted.Signing.Client": "[1.0.60, )",
+          "Microsoft.Windows.SDK.BuildTools": "[10.0.22621.3233, )",
+          "NetOfficeFw.Core": "[2.0.0, )",
           "stdole": "[7.0.3300, )"
         }
       }

--- a/Source/Office/packages.lock.json
+++ b/Source/Office/packages.lock.json
@@ -12,6 +12,18 @@
           "Microsoft.SourceLink.Common": "1.1.1"
         }
       },
+      "Microsoft.Trusted.Signing.Client": {
+        "type": "Direct",
+        "requested": "[1.0.60, )",
+        "resolved": "1.0.60",
+        "contentHash": "FTMmjIfofcvi3KTcyMKzAI1nIo+kvswo8HdsWWpLAomYyy85LixevLutCipU6nNv9E1iLuZWkZE6OoPhbu2QAg=="
+      },
+      "Microsoft.Windows.SDK.BuildTools": {
+        "type": "Direct",
+        "requested": "[10.0.22621.3233, )",
+        "resolved": "10.0.22621.3233",
+        "contentHash": "v67zwCb9JOpfPxdSroZukIKHruU6FUB+KwcmSPcVvUFyYtcyvcUign5y8jPQNi54CVzWvaTg646e62LbanUkxg=="
+      },
       "stdole": {
         "type": "Direct",
         "requested": "[7.0.3300, )",
@@ -29,7 +41,11 @@
         "contentHash": "WMcGpWKrmJmzrNeuaEb23bEMnbtR/vLmvZtkAP5qWu7vQsY59GqfRJd65sFpBszbd2k/bQ8cs8eWawQKAabkVg=="
       },
       "NetOfficeFw.Core": {
-        "type": "Project"
+        "type": "Project",
+        "dependencies": {
+          "Microsoft.Trusted.Signing.Client": "[1.0.60, )",
+          "Microsoft.Windows.SDK.BuildTools": "[10.0.22621.3233, )"
+        }
       }
     }
   }

--- a/Source/Outlook/packages.lock.json
+++ b/Source/Outlook/packages.lock.json
@@ -12,6 +12,18 @@
           "Microsoft.SourceLink.Common": "1.1.1"
         }
       },
+      "Microsoft.Trusted.Signing.Client": {
+        "type": "Direct",
+        "requested": "[1.0.60, )",
+        "resolved": "1.0.60",
+        "contentHash": "FTMmjIfofcvi3KTcyMKzAI1nIo+kvswo8HdsWWpLAomYyy85LixevLutCipU6nNv9E1iLuZWkZE6OoPhbu2QAg=="
+      },
+      "Microsoft.Windows.SDK.BuildTools": {
+        "type": "Direct",
+        "requested": "[10.0.22621.3233, )",
+        "resolved": "10.0.22621.3233",
+        "contentHash": "v67zwCb9JOpfPxdSroZukIKHruU6FUB+KwcmSPcVvUFyYtcyvcUign5y8jPQNi54CVzWvaTg646e62LbanUkxg=="
+      },
       "stdole": {
         "type": "Direct",
         "requested": "[7.0.3300, )",
@@ -29,12 +41,18 @@
         "contentHash": "WMcGpWKrmJmzrNeuaEb23bEMnbtR/vLmvZtkAP5qWu7vQsY59GqfRJd65sFpBszbd2k/bQ8cs8eWawQKAabkVg=="
       },
       "NetOfficeFw.Core": {
-        "type": "Project"
+        "type": "Project",
+        "dependencies": {
+          "Microsoft.Trusted.Signing.Client": "[1.0.60, )",
+          "Microsoft.Windows.SDK.BuildTools": "[10.0.22621.3233, )"
+        }
       },
       "NetOfficeFw.Office": {
         "type": "Project",
         "dependencies": {
-          "NetOfficeFw.Core": "[1.9.3, )",
+          "Microsoft.Trusted.Signing.Client": "[1.0.60, )",
+          "Microsoft.Windows.SDK.BuildTools": "[10.0.22621.3233, )",
+          "NetOfficeFw.Core": "[2.0.0, )",
           "stdole": "[7.0.3300, )"
         }
       }

--- a/Source/PowerPoint/packages.lock.json
+++ b/Source/PowerPoint/packages.lock.json
@@ -12,6 +12,18 @@
           "Microsoft.SourceLink.Common": "1.1.1"
         }
       },
+      "Microsoft.Trusted.Signing.Client": {
+        "type": "Direct",
+        "requested": "[1.0.60, )",
+        "resolved": "1.0.60",
+        "contentHash": "FTMmjIfofcvi3KTcyMKzAI1nIo+kvswo8HdsWWpLAomYyy85LixevLutCipU6nNv9E1iLuZWkZE6OoPhbu2QAg=="
+      },
+      "Microsoft.Windows.SDK.BuildTools": {
+        "type": "Direct",
+        "requested": "[10.0.22621.3233, )",
+        "resolved": "10.0.22621.3233",
+        "contentHash": "v67zwCb9JOpfPxdSroZukIKHruU6FUB+KwcmSPcVvUFyYtcyvcUign5y8jPQNi54CVzWvaTg646e62LbanUkxg=="
+      },
       "stdole": {
         "type": "Direct",
         "requested": "[7.0.3300, )",
@@ -29,20 +41,28 @@
         "contentHash": "WMcGpWKrmJmzrNeuaEb23bEMnbtR/vLmvZtkAP5qWu7vQsY59GqfRJd65sFpBszbd2k/bQ8cs8eWawQKAabkVg=="
       },
       "NetOfficeFw.Core": {
-        "type": "Project"
+        "type": "Project",
+        "dependencies": {
+          "Microsoft.Trusted.Signing.Client": "[1.0.60, )",
+          "Microsoft.Windows.SDK.BuildTools": "[10.0.22621.3233, )"
+        }
       },
       "NetOfficeFw.Office": {
         "type": "Project",
         "dependencies": {
-          "NetOfficeFw.Core": "[1.9.3, )",
+          "Microsoft.Trusted.Signing.Client": "[1.0.60, )",
+          "Microsoft.Windows.SDK.BuildTools": "[10.0.22621.3233, )",
+          "NetOfficeFw.Core": "[2.0.0, )",
           "stdole": "[7.0.3300, )"
         }
       },
       "NetOfficeFw.VBIDE": {
         "type": "Project",
         "dependencies": {
-          "NetOfficeFw.Core": "[1.9.3, )",
-          "NetOfficeFw.Office": "[1.9.3, )"
+          "Microsoft.Trusted.Signing.Client": "[1.0.60, )",
+          "Microsoft.Windows.SDK.BuildTools": "[10.0.22621.3233, )",
+          "NetOfficeFw.Core": "[2.0.0, )",
+          "NetOfficeFw.Office": "[2.0.0, )"
         }
       }
     }

--- a/Source/VBIDE/packages.lock.json
+++ b/Source/VBIDE/packages.lock.json
@@ -12,6 +12,18 @@
           "Microsoft.SourceLink.Common": "1.1.1"
         }
       },
+      "Microsoft.Trusted.Signing.Client": {
+        "type": "Direct",
+        "requested": "[1.0.60, )",
+        "resolved": "1.0.60",
+        "contentHash": "FTMmjIfofcvi3KTcyMKzAI1nIo+kvswo8HdsWWpLAomYyy85LixevLutCipU6nNv9E1iLuZWkZE6OoPhbu2QAg=="
+      },
+      "Microsoft.Windows.SDK.BuildTools": {
+        "type": "Direct",
+        "requested": "[10.0.22621.3233, )",
+        "resolved": "10.0.22621.3233",
+        "contentHash": "v67zwCb9JOpfPxdSroZukIKHruU6FUB+KwcmSPcVvUFyYtcyvcUign5y8jPQNi54CVzWvaTg646e62LbanUkxg=="
+      },
       "Microsoft.Build.Tasks.Git": {
         "type": "Transitive",
         "resolved": "1.1.1",
@@ -28,12 +40,18 @@
         "contentHash": "p9WhjNp/gM2z80u+xNA1XXFek57iybUUJaDnQooKfdct3vGIpmDzLdL7Rq4ZmFzZc3LN3SFs5bRIE7j/+gLn5Q=="
       },
       "NetOfficeFw.Core": {
-        "type": "Project"
+        "type": "Project",
+        "dependencies": {
+          "Microsoft.Trusted.Signing.Client": "[1.0.60, )",
+          "Microsoft.Windows.SDK.BuildTools": "[10.0.22621.3233, )"
+        }
       },
       "NetOfficeFw.Office": {
         "type": "Project",
         "dependencies": {
-          "NetOfficeFw.Core": "[1.9.3, )",
+          "Microsoft.Trusted.Signing.Client": "[1.0.60, )",
+          "Microsoft.Windows.SDK.BuildTools": "[10.0.22621.3233, )",
+          "NetOfficeFw.Core": "[2.0.0, )",
           "stdole": "[7.0.3300, )"
         }
       }

--- a/Source/Word/packages.lock.json
+++ b/Source/Word/packages.lock.json
@@ -12,6 +12,18 @@
           "Microsoft.SourceLink.Common": "1.1.1"
         }
       },
+      "Microsoft.Trusted.Signing.Client": {
+        "type": "Direct",
+        "requested": "[1.0.60, )",
+        "resolved": "1.0.60",
+        "contentHash": "FTMmjIfofcvi3KTcyMKzAI1nIo+kvswo8HdsWWpLAomYyy85LixevLutCipU6nNv9E1iLuZWkZE6OoPhbu2QAg=="
+      },
+      "Microsoft.Windows.SDK.BuildTools": {
+        "type": "Direct",
+        "requested": "[10.0.22621.3233, )",
+        "resolved": "10.0.22621.3233",
+        "contentHash": "v67zwCb9JOpfPxdSroZukIKHruU6FUB+KwcmSPcVvUFyYtcyvcUign5y8jPQNi54CVzWvaTg646e62LbanUkxg=="
+      },
       "stdole": {
         "type": "Direct",
         "requested": "[7.0.3300, )",
@@ -29,20 +41,28 @@
         "contentHash": "WMcGpWKrmJmzrNeuaEb23bEMnbtR/vLmvZtkAP5qWu7vQsY59GqfRJd65sFpBszbd2k/bQ8cs8eWawQKAabkVg=="
       },
       "NetOfficeFw.Core": {
-        "type": "Project"
+        "type": "Project",
+        "dependencies": {
+          "Microsoft.Trusted.Signing.Client": "[1.0.60, )",
+          "Microsoft.Windows.SDK.BuildTools": "[10.0.22621.3233, )"
+        }
       },
       "NetOfficeFw.Office": {
         "type": "Project",
         "dependencies": {
-          "NetOfficeFw.Core": "[1.9.3, )",
+          "Microsoft.Trusted.Signing.Client": "[1.0.60, )",
+          "Microsoft.Windows.SDK.BuildTools": "[10.0.22621.3233, )",
+          "NetOfficeFw.Core": "[2.0.0, )",
           "stdole": "[7.0.3300, )"
         }
       },
       "NetOfficeFw.VBIDE": {
         "type": "Project",
         "dependencies": {
-          "NetOfficeFw.Core": "[1.9.3, )",
-          "NetOfficeFw.Office": "[1.9.3, )"
+          "Microsoft.Trusted.Signing.Client": "[1.0.60, )",
+          "Microsoft.Windows.SDK.BuildTools": "[10.0.22621.3233, )",
+          "NetOfficeFw.Core": "[2.0.0, )",
+          "NetOfficeFw.Office": "[2.0.0, )"
         }
       }
     }

--- a/Source/trustedsigning.json
+++ b/Source/trustedsigning.json
@@ -1,0 +1,5 @@
+{
+  "Endpoint": "https://weu.codesigning.azure.net/",
+  "CodeSigningAccountName": "OpenSourceSigning",
+  "CertificateProfileName": "JozefIzsoOpenSourceProfile"
+}


### PR DESCRIPTION
All NetOffice libraries are signed by the Azure Trusted Signing service by an open source developer certificate.

The nuget packages are not signed because ATS tooling does not support those yet.