### PR TITLE
Modernize `release` workflow for v1.9.x releases

### DIFF
--- a/.github/Get-BuildInfo.ps1
+++ b/.github/Get-BuildInfo.ps1
@@ -58,3 +58,4 @@ Write-GitHubVariable "app_version_suffix" $app_version_suffix
 Write-GitHubVariable "app_version_full" $app_version_full
 Write-GitHubVariable "sign_binaries" $sign_binaries
 Write-GitHubVariable "publish_nuget" $publish_nuget
+Write-GitHubVariable "nuget_packages_artifact_name" "NetOffice_packages_v$app_version_full"

--- a/.github/workflows/labels.yml
+++ b/.github/workflows/labels.yml
@@ -14,7 +14,7 @@ jobs:
   labels:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: gitlabels/gitlabels@v1
+      - uses: actions/checkout@v5
+      - uses: gitlabels/gitlabels@v2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -106,28 +106,28 @@ jobs:
         path: '${{ github.workspace }}\Source\ClientApplication\bin\${{ matrix.configuration }}'
 
     - name: Pack NetOffice
-      if: steps.build.outputs.publish_nuget == 'true'
       run: |
         dotnet pack --no-build --no-restore Source\NetOffice.sln -c ${{ matrix.configuration }} -o dist
       env:
         VersionSuffix: ${{ steps.build.outputs.app_version_suffix }}
 
-    # - name: Sign NetOffice packages
-    #   if: success() && steps.build.outputs.publish_nuget == 'true' && steps.build.outputs.sign_binaries == 'true'
-    #   working-directory: '${{ github.workspace}}\dist'
-    #   run: |
-    #       NuGetKeyVaultSignTool.exe sign *.nupkg `
-    #       --file-digest sha256 `
-    #       --timestamp-rfc3161 http://timestamp.digicert.com `
-    #       --timestamp-digest sha256 `
-    #       --azure-key-vault-url https://opensourcesigning.vault.azure.net `
-    #       --azure-key-vault-tenant-id "${{ secrets.KEYVAULT_TENANT_ID }}" `
-    #       --azure-key-vault-client-id "${{ secrets.KEYVAULT_CLIENT_ID }}" `
-    #       --azure-key-vault-client-secret "${{ secrets.KEYVAULT_CLIENT_SECRET }}" `
-    #       --azure-key-vault-certificate "goITSolutions-until-2024-01"
+    - name: Sign NetOffice packages
+      if: success() && steps.build.outputs.sign_binaries == 'true'
+      working-directory: '${{ github.workspace}}\dist'
+      run: |
+        sign code trusted-signing *.nupkg `
+        --publisher-name "NetOffice" `
+        --description "NetOffice" `
+        --description-url "https://github.com/NetOfficeFw/NetOffice" `
+        --trusted-signing-endpoint "${{ secrets.TRUSTED_SIGNING_ENDPOINT }}" `
+        --trusted-signing-account "${{ secrets.TRUSTED_SIGNING_ACCOUNT_NAME }}" `
+        --trusted-signing-certificate-profile "${{ secrets.TRUSTED_SIGNING_CERTIFICATE_PROFILE }}" `
+        --file-digest SHA256 `
+        --timestamp-url http://timestamp.acs.microsoft.com `
+        --timestamp-digest SHA256
 
     - name: Publish packages
-      if: success()  && steps.build.outputs.publish_nuget == 'true'
+      if: success() && steps.build.outputs.publish_nuget == 'true'
       working-directory: '${{ github.workspace}}\dist'
       run: |
         dotnet nuget push *.nupkg --api-key $env:NUGET_TOKEN --source https://api.nuget.org/v3/index.json
@@ -135,7 +135,7 @@ jobs:
         NUGET_TOKEN: ${{ secrets.NUGET_TOKEN }}
 
     - name: Archive NetOffice packages
-      if: success() && steps.build.outputs.publish_nuget == 'true'
+      if: success()
       uses: actions/upload-artifact@v5
       with:
         name: NetOffice_packages_v${{ steps.build.outputs.app_version_full }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,6 +29,9 @@ jobs:
       RepositoryCommit: '${{ github.sha }}'
       Configuration: '${{ matrix.configuration }}'
 
+    outputs:
+      nuget_packages_artifact_name: ${{ steps.build.outputs.nuget_packages_artifact_name }}
+
     steps:
     - name: Checkout
       uses: actions/checkout@v5
@@ -147,17 +150,52 @@ jobs:
         $nupkg = Get-ChildItem -Path '${{ github.workspace}}\dist' -Filter '*.nupkg' | Select-Object -First 1
         nuget-cert-extractor --file $nupkg --output '${{ github.workspace}}\dist' --code-signing --author --leaf
 
-    - name: Publish packages
-      if: success() && steps.build.outputs.publish_nuget == 'true'
-      working-directory: '${{ github.workspace}}\dist'
-      run: |
-        dotnet nuget push *.nupkg --api-key $env:NUGET_TOKEN --source https://api.nuget.org/v3/index.json
-      env:
-        NUGET_TOKEN: ${{ secrets.NUGET_TOKEN }}
-
     - name: Archive NetOffice packages
       if: success()
       uses: actions/upload-artifact@v5
       with:
-        name: NetOffice_packages_v${{ steps.build.outputs.app_version_full }}
+        name: ${{ steps.build.outputs.nuget_packages_artifact_name }}
         path: '${{ github.workspace }}\dist'
+
+    - name: Archive code signing certificate
+      if: success() && matrix.configuration == 'Release'
+      uses: actions/upload-artifact@v5
+      with:
+        name: certificate
+        path: '${{ github.workspace }}/dist/*.cer'
+
+    - name: Release documentation
+      if: matrix.configuration == 'Release'
+      run: |
+        'To release the NuGet package, upload the signing certificate to NuGet Gallery via Account Settings: <https://www.nuget.org/account>.  ' >> $env:GITHUB_STEP_SUMMARY
+        'See the `certificate` artifact for the signing certificate file.' >> $env:GITHUB_STEP_SUMMARY
+        '' >> $env:GITHUB_STEP_SUMMARY
+        'Approve the `publish` job deployment to the `nuget-gallery` environment when the certificate was added to NuGet Gallery.' >> $env:GITHUB_STEP_SUMMARY
+
+  publish:
+    environment: nuget-gallery
+
+    permissions:
+      id-token: write
+
+    needs: release
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Download NetOffice packages
+      uses: actions/download-artifact@v5
+      with:
+        name: ${{ needs.release.outputs.nuget_packages_artifact_name }}
+    
+    - name: Authenticate Nuget Gallery
+      uses: NuGet/login@v1
+      id: nuget
+      with:
+        user: ${{ secrets.NUGET_TRUSTED_PUBLISHING_USER }}
+
+    - name: Publish packages
+      run: |
+        dotnet nuget push "*.nupkg" --api-key "$NUGET_API_KEY" --source https://api.nuget.org/v3/index.json
+      env:
+        NUGET_API_KEY: ${{ steps.nuget.outputs.NUGET_API_KEY }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,11 +47,11 @@ jobs:
 
     - name: Setup AzureSignTool
       if: steps.cache-dotnettools.outputs.cache-hit != 'true'
-      run: dotnet tool install --verbosity minimal --global azuresigntool --version 3.0.0
+      run: dotnet tool install --verbosity minimal --global azuresigntool --version 6.0.1
 
     - name: Setup NuGetKeyVaultSignTool
       if: steps.cache-dotnettools.outputs.cache-hit != 'true'
-      run: dotnet tool install --verbosity minimal --global NuGetKeyVaultSignTool --version 3.2.2
+      run: dotnet tool install --verbosity minimal --global NuGetKeyVaultSignTool --version 3.2.3
 
     - name: Cache packages
       uses: actions/cache@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,18 +28,18 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v5
 
     - name: Setup dotnet
-      uses: actions/setup-dotnet@v3
+      uses: actions/setup-dotnet@v5
       with:
         dotnet-version: '7.0.201'
 
     - name: Setup MSBuild
-      uses: microsoft/setup-msbuild@v1.1
+      uses: microsoft/setup-msbuild@v2
 
     - name: Cache dotnet tools
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       id: cache-dotnettools
       with:
         path: ~/.dotnet/tools
@@ -54,7 +54,7 @@ jobs:
       run: dotnet tool install --verbosity minimal --global NuGetKeyVaultSignTool --version 3.2.2
 
     - name: Cache packages
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: ~/.nuget/packages
         key: NetOffice-nuget-${{ hashFiles('**/packages.lock.json') }}
@@ -93,7 +93,7 @@ jobs:
           timestamp-digest: SHA256
 
     - name: Archive NetOffice binaries
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v5
       with:
         name: NetOffice_binaries_v${{ steps.build.outputs.app_version_full }}_${{ matrix.configuration }}
         path: '${{ github.workspace }}\Source\ClientApplication\bin\${{ matrix.configuration }}'
@@ -129,7 +129,7 @@ jobs:
 
     - name: Archive NetOffice packages
       if: success() && steps.build.outputs.publish_nuget == 'true'
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v5
       with:
         name: NetOffice_packages_v${{ steps.build.outputs.app_version_full }}
         path: '${{ github.workspace }}\dist'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,10 +6,13 @@ on:
       - 'v*.*.*'
 
 permissions:
+  id-token: write
   contents: read
 
 jobs:
   release:
+    environment: production
+
     runs-on: windows-2022
 
     strategy:
@@ -45,13 +48,13 @@ jobs:
         path: ~/.dotnet/tools
         key: dotnettools
 
-    - name: Setup AzureSignTool
+    - name: Setup dotnet sign tool
       if: steps.cache-dotnettools.outputs.cache-hit != 'true'
-      run: dotnet tool install --verbosity minimal --global azuresigntool --version 6.0.1
+      run: dotnet tool install --verbosity minimal --global sign --version 0.9.1-beta.25379.1
 
-    - name: Setup NuGetKeyVaultSignTool
+    - name: Setup Knapcode.CertificateExtractor tool
       if: steps.cache-dotnettools.outputs.cache-hit != 'true'
-      run: dotnet tool install --verbosity minimal --global NuGetKeyVaultSignTool --version 3.2.3
+      run: dotnet tool install --verbosity minimal --global Knapcode.CertificateExtractor --version 0.1.1
 
     - name: Cache packages
       uses: actions/cache@v4
@@ -77,20 +80,24 @@ jobs:
         $content = $content.Replace('${{ github.workspace }}', '..')
         $content | Set-Content obj/signlist.txt
 
+    - name: azure login
+      uses: azure/login@v2
+      with:
+        client-id: ${{ secrets.TRUSTED_SIGNING_CLIENT_ID }}
+        subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+        tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+
     - name: Sign NetOffice libraries
       if: success() && steps.build.outputs.sign_binaries == 'true'
-      uses: azure/trusted-signing-action@v0.3.19
+      uses: azure/trusted-signing-action@v0.5.10
       with:
-          azure-tenant-id: ${{ secrets.KEYVAULT_TENANT_ID }}
-          azure-client-id: ${{ secrets.KEYVAULT_CLIENT_ID }}
-          azure-client-secret: ${{ secrets.KEYVAULT_CLIENT_SECRET }}
-          endpoint: ${{ vars.KEYVAULT_ENDPOINT }}
-          trusted-signing-account-name: ${{ vars.KEYVAULT_ACCOUNT_NAME }}
-          certificate-profile-name: ${{ secrets.KEYVAULT_CERTIFICATE_PROFILE }}
-          files-catalog: '${{ github.workspace }}/obj/signlist.txt'
-          file-digest: SHA256
-          timestamp-rfc3161: http://timestamp.acs.microsoft.com
-          timestamp-digest: SHA256
+        endpoint: ${{ secrets.TRUSTED_SIGNING_ENDPOINT }}
+        trusted-signing-account-name: ${{ secrets.TRUSTED_SIGNING_ACCOUNT_NAME }}
+        certificate-profile-name: ${{ secrets.TRUSTED_SIGNING_CERTIFICATE_PROFILE }}
+        files-catalog: '${{ github.workspace }}/obj/signlist.txt'
+        file-digest: SHA256
+        timestamp-rfc3161: http://timestamp.acs.microsoft.com
+        timestamp-digest: SHA256
 
     - name: Archive NetOffice binaries
       uses: actions/upload-artifact@v5

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,7 +33,7 @@ jobs:
     - name: Setup dotnet
       uses: actions/setup-dotnet@v5
       with:
-        dotnet-version: '7.0.201'
+        dotnet-version: 8
 
     - name: Setup MSBuild
       uses: microsoft/setup-msbuild@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -95,6 +95,21 @@ jobs:
         trusted-signing-account-name: ${{ secrets.TRUSTED_SIGNING_ACCOUNT_NAME }}
         certificate-profile-name: ${{ secrets.TRUSTED_SIGNING_CERTIFICATE_PROFILE }}
         files-catalog: '${{ github.workspace }}/obj/signlist.txt'
+        files: |
+          ${{ github.workspace }}/Source/ClientApplication/bin/${{ matrix.configuration }}/AccessApi.dll
+          ${{ github.workspace }}/Source/ClientApplication/bin/${{ matrix.configuration }}/ADODBApi.dll
+          ${{ github.workspace }}/Source/ClientApplication/bin/${{ matrix.configuration }}/DAOApi.dll
+          ${{ github.workspace }}/Source/ClientApplication/bin/${{ matrix.configuration }}/ExcelApi.dll
+          ${{ github.workspace }}/Source/ClientApplication/bin/${{ matrix.configuration }}/MSComctlLibApi.dll
+          ${{ github.workspace }}/Source/ClientApplication/bin/${{ matrix.configuration }}/MSDATASRCApi.dll
+          ${{ github.workspace }}/Source/ClientApplication/bin/${{ matrix.configuration }}/NetOffice.dll
+          ${{ github.workspace }}/Source/ClientApplication/bin/${{ matrix.configuration }}/OfficeApi.dll
+          ${{ github.workspace }}/Source/ClientApplication/bin/${{ matrix.configuration }}/OfficeApi.Extensions.dll
+          ${{ github.workspace }}/Source/ClientApplication/bin/${{ matrix.configuration }}/OutlookApi.dll
+          ${{ github.workspace }}/Source/ClientApplication/bin/${{ matrix.configuration }}/OWC10Api.dll
+          ${{ github.workspace }}/Source/ClientApplication/bin/${{ matrix.configuration }}/PowerPointApi.dll
+          ${{ github.workspace }}/Source/ClientApplication/bin/${{ matrix.configuration }}/VBIDEApi.dll
+          ${{ github.workspace }}/Source/ClientApplication/bin/${{ matrix.configuration }}/WordApi.dll
         file-digest: SHA256
         timestamp-rfc3161: http://timestamp.acs.microsoft.com
         timestamp-digest: SHA256

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -141,6 +141,12 @@ jobs:
         --timestamp-url http://timestamp.acs.microsoft.com `
         --timestamp-digest SHA256
 
+    - name: Extract trusted signing certificate
+      if: success() && steps.build.outputs.sign_binaries == 'true'
+      run: |
+        $nupkg = Get-ChildItem -Path '${{ github.workspace}}\dist' -Filter '*.nupkg' | Select-Object -First 1
+        nuget-cert-extractor --file $nupkg --output '${{ github.workspace}}\dist' --code-signing --author --leaf
+
     - name: Publish packages
       if: success() && steps.build.outputs.publish_nuget == 'true'
       working-directory: '${{ github.workspace}}\dist'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -31,18 +31,18 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v5
 
     - name: Setup dotnet
-      uses: actions/setup-dotnet@v3
+      uses: actions/setup-dotnet@v5
       with:
         dotnet-version: '7.0.201'
 
     - name: Setup MSBuild
-      uses: microsoft/setup-msbuild@v1.1
+      uses: microsoft/setup-msbuild@v2
 
     - name: Cache packages
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: ~/.nuget/packages
         key: NetOffice-nuget-${{ hashFiles('**/packages.lock.json') }}
@@ -66,7 +66,7 @@ jobs:
         VersionSuffix: ${{ steps.build.outputs.app_version_suffix }}
 
     - name: Archive NetOffice binaries
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v5
       with:
         name: NetOffice_binaries_v${{ steps.build.outputs.app_version_full }}_${{ matrix.configuration }}
         path: '${{ github.workspace }}\Source\ClientApplication\bin\${{ matrix.configuration }}'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -36,7 +36,7 @@ jobs:
     - name: Setup dotnet
       uses: actions/setup-dotnet@v5
       with:
-        dotnet-version: '7.0.201'
+        dotnet-version: 8
 
     - name: Setup MSBuild
       uses: microsoft/setup-msbuild@v2

--- a/Source/ClientApplication/packages.lock.json
+++ b/Source/ClientApplication/packages.lock.json
@@ -167,6 +167,6 @@
         }
       }
     },
-    ".NETFramework,Version=v4.6.2/win7-x86": {}
+    ".NETFramework,Version=v4.6.2/win-x86": {}
   }
 }


### PR DESCRIPTION
To continue releasing bugfixes in the `v1.9` train the `release` workflow is modernized with support for Azure Trusted Signing and NuGet Trusted Publishing.

The workflow will use federated OIDC logins to Azure and NuGet to minimize secret tokens management.

Workflow is split to two parts. Release will build and digitally signed NetOffice assemblies and it will create the legacy archive and all nuget packages. As the Azure Trusted Signing is used short lived three day certificates and the NuGet Gallery does not support the **Public Trust Identity EKU** yet (see https://github.com/NuGet/NuGetGallery/issues/10027), developer must manually download the `certificate` artifact and upload the `.cer` file to NuGet Account for NetOffice.

The `nuget-gallery` environment is gated by manual approval, so the second part of the release workflow will run only after the certificate was uploaded to NuGet Gallyer account.