### PR TITLE
Update reference to `NetOfficeFw.Word` project

### DIFF
--- a/Source/NetOffice.Tests/packages.lock.json
+++ b/Source/NetOffice.Tests/packages.lock.json
@@ -181,19 +181,21 @@
           "NetOfficeFw.Office": "[2.0.0, )"
         }
       },
+      "NetOfficeFw.Word": {
+        "type": "Project",
+        "dependencies": {
+          "Microsoft.Trusted.Signing.Client": "[1.0.60, )",
+          "Microsoft.Windows.SDK.BuildTools": "[10.0.22621.3233, )",
+          "NetOfficeFw.Core": "[2.0.0, )",
+          "NetOfficeFw.Office": "[2.0.0, )",
+          "NetOfficeFw.VBIDE": "[2.0.0, )",
+          "stdole": "[7.0.3300, )"
+        }
+      },
       "noassemblytitle": {
         "type": "Project",
         "dependencies": {
           "NetOfficeFw.Core": "[2.0.0, )"
-        }
-      },
-      "NetOfficeFw.Word": {
-        "type": "Project",
-        "dependencies": {
-          "NetOfficeFw.Core": "[1.9.3, )",
-          "NetOfficeFw.Office": "[1.9.3, )",
-          "NetOfficeFw.VBIDE": "[1.9.3, )",
-          "stdole": "[7.0.3300, )"
         }
       }
     }


### PR DESCRIPTION
Update the reference to `NetOfficeFw.Word` project from the `NetOffice.Tests` to fix build problem:


```
D:\a\NetOffice\NetOffice\Source\NetOffice.Tests\NetOffice.Tests.csproj : error NU1004: The project reference NetOfficeFw.Word has changed. Current dependencies:

D:\a\NetOffice\NetOffice\Source\NetOffice\NetOffice.csproj,
D:\a\NetOffice\NetOffice\Source\Office\OfficeApi.csproj,
D:\a\NetOffice\NetOffice\Source\VBIDE\VBIDEApi.csproj,
Microsoft.Trusted.Signing.Client,Microsoft.Windows.SDK.BuildTools,
stdole

lock file's dependencies:
NetOfficeFw.Core,
NetOfficeFw.Office,
NetOfficeFw.VBIDE,
stdole.

The packages lock file is inconsistent with the project dependencies so restore can't be run in locked mode.
Disable the RestoreLockedMode MSBuild property or pass an explicit --force-evaluate option to run restore to update the lock file. 

[D:\a\NetOffice\NetOffice\Source\NetOffice.sln]
```


### Analysis

The regression was introduced by commit d912892ae - `Fix bug in DocumentEvents2 sink implementation of the ContentControlBeforeContentUpdate event`.

That commit added a new Word test project reference in Source/NetOffice.Tests/NetOffice.Tests.csproj:32:

```xml
<ProjectReference Include="..\Word\WordApi.csproj" />
```

and also added a `NetOfficeFw.Word` entry to `Source/NetOffice.Tests/packages.lock.json`, but it wrote stale dependencies for that project:

- lock file entry added by d912892ae: `NetOfficeFw.Core`, `NetOfficeFw.Office`, `NetOfficeFw.VBIDE`, `stdole` with old 1.9.3 ranges
- actual current dependencies of `Source/Word/WordApi.csproj` are:
    - `Source/NetOffice/NetOffice.csproj`
    - `Source/Office/OfficeApi.csproj`
    - `Source/VBIDE/VBIDEApi.csproj`
    - `Microsoft.Trusted.Signing.Client`
    - `Microsoft.Windows.SDK.BuildTools`
    - `stdole`