### PR TITLE
Add changelog entry for `Presentation.AutoSaveOn` released in v1.9.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@
 ### Fixed
 * Fix bug in `ContentControlBeforeContentUpdate` code by verifying the correct event name [#454](https://github.com/NetOfficeFw/NetOffice/pull/454)
 
+### Added
+* Added `Presentation.AutoSaveOn` property in PowerPoint library [#438](https://github.com/NetOfficeFw/NetOffice/issues/438)
+
 
 ## v1.9.7
 


### PR DESCRIPTION
Document the missing addition of the `Presentation.AutoSaveOn` property in v1.9.8 release.