### PR TITLE
Make `COMDynamicMetaObject` and `DynamicObjectEntity` classes obsolete

### DIFF
--- a/Source/NetOffice/Core.cs
+++ b/Source/NetOffice/Core.cs
@@ -182,6 +182,7 @@ namespace NetOffice
         /// <summary>
         /// Occurs when a new COMDynamicObject instance should be created
         /// </summary>
+        [Obsolete("Support for dynamic objects will be removed in NetOffice 2.0")]
         public event OnCreateCOMDynamicEventHandler CreateCOMDynamic;
 
         /// <summary>
@@ -190,6 +191,7 @@ namespace NetOffice
         /// <param name="instance">requested instance</param>
         /// <param name="comProxy">target proxy</param>
         /// <returns>COMDynamicObject instance or null</returns>
+        [Obsolete("Support for dynamic objects will be removed in NetOffice 2.0")]
         private COMDynamicObject RaiseCreateCOMDynamic(ICOMObject instance, object comProxy)
         {
             if (null != CreateCOMDynamic)

--- a/Source/NetOffice/CoreExtensions/Core.Nested.cs
+++ b/Source/NetOffice/CoreExtensions/Core.Nested.cs
@@ -61,6 +61,7 @@ namespace NetOffice
         /// <summary>
         /// Arguments in CreateCOMDynamicEvent event
         /// </summary>
+        [Obsolete("Support for dynamic objects will be removed in NetOffice 2.0")]
         public class OnCreateCOMDynamicEventArgs : EventArgs
         {
             /// <summary>
@@ -201,6 +202,7 @@ namespace NetOffice
         /// </summary>
         /// <param name="sender">Core sender instance</param>
         /// <param name="args">args as provided</param>
+        [Obsolete("Support for dynamic objects will be removed in NetOffice 2.0")]
         public delegate void OnCreateCOMDynamicEventHandler(Core sender, OnCreateCOMDynamicEventArgs args);
 
         /// <summary>

--- a/Source/NetOffice/Dynamics/COMDynamicMetaObject.cs
+++ b/Source/NetOffice/Dynamics/COMDynamicMetaObject.cs
@@ -10,6 +10,7 @@ namespace NetOffice.Dynamics
     /// <summary>
     /// Wrapper around underlying DynamicMetaObject for debugging purposes.
     /// </summary>
+    [Obsolete("Support for dynamic objects will be removed in NetOffice 2.0")]
     public class COMDynamicMetaObject : DynamicMetaObject
     {
         /// <summary>

--- a/Source/NetOffice/Dynamics/COMDynamicMetaObject.cs
+++ b/Source/NetOffice/Dynamics/COMDynamicMetaObject.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Dynamic;
 
 namespace NetOffice.Dynamics

--- a/Source/NetOffice/Dynamics/DynamicObjectEntity.cs
+++ b/Source/NetOffice/Dynamics/DynamicObjectEntity.cs
@@ -8,6 +8,7 @@ namespace NetOffice
     /// <summary>
     /// Runtime Entity Description
     /// </summary>
+    [Obsolete("Support for dynamic objects will be removed in NetOffice 2.0")]
     public class DynamicObjectEntity
     {
         /// <summary>


### PR DESCRIPTION
These classes will be removed in NetOffice 2.0